### PR TITLE
Add honeypot spam protection

### DIFF
--- a/cloudflare/contact-us-worker.js
+++ b/cloudflare/contact-us-worker.js
@@ -45,6 +45,14 @@ async function handleRequest(request) {
 
   try {
     const formData = await request.formData();
+    const website = formData.get('website');
+    if (website) {
+      return new Response(JSON.stringify({ success: false, message: 'Bot detected' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': ALLOWED_ORIGIN },
+      });
+    }
+
     const name = formData.get('name');
     const email = formData.get('email');
     const contactNumber = formData.get('contactNumber'); // Matches 'contact-number' from HTML

--- a/cloudflare/join-us-worker.js
+++ b/cloudflare/join-us-worker.js
@@ -45,6 +45,14 @@ async function handleRequest(request) {
 
   try {
     const formData = await request.formData();
+    const website = formData.get('website');
+    if (website) {
+      return new Response(JSON.stringify({ success: false, message: 'Bot detected' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': ALLOWED_ORIGIN },
+      });
+    }
+
     const name = formData.get('name');
     const email = formData.get('email');
     const contact = formData.get('contact');

--- a/css/global.css
+++ b/css/global.css
@@ -63,6 +63,12 @@ body[data-theme="dark"] .collapsible-content label {
   box-sizing: border-box;
 }
 
+/* Honeypot field hidden from users */
+.honeypot {
+  position: absolute !important;
+  left: -9999px !important;
+}
+
 body {
   font-family: Arial, sans-serif;
   background-color: #f4f4f4;

--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
                 </div>
                 <div class="modal-body">
                     <form id="join-form">
+                        <input type="text" name="website" id="honeypot-join" class="honeypot" autocomplete="off">
                         <div class="form-row">
                             <div class="form-cell">
                                 <label for="join-name" data-en="Name" data-es="Nombre">Name</label>
@@ -292,6 +293,7 @@
                 </div>
                 <div class="modal-body">
                     <form id="contact-form">
+                        <input type="text" name="website" id="honeypot-contact" class="honeypot" autocomplete="off">
                         <div class="form-row">
                             <div class="form-cell">
                                 <label for="contact-name" data-en="Name" data-es="Nombre">Name</label>

--- a/js/main.js
+++ b/js/main.js
@@ -224,6 +224,12 @@ document.addEventListener("DOMContentLoaded", () => {
     joinForm.addEventListener('submit', (e) => {
       e.preventDefault();
 
+      const honey = document.getElementById('honeypot-join');
+      if (honey && honey.value) {
+        alert('Submission blocked.');
+        return;
+      }
+
       if (typeof grecaptcha === 'undefined' || typeof grecaptcha.execute === 'undefined') {
           console.error('ReCAPTCHA not loaded yet.');
           alert('ReCAPTCHA is not ready. Please try again in a moment.');
@@ -292,6 +298,12 @@ document.addEventListener("DOMContentLoaded", () => {
   if (contactForm) {
     contactForm.addEventListener('submit', (e) => {
       e.preventDefault();
+
+      const honey = document.getElementById('honeypot-contact');
+      if (honey && honey.value) {
+        alert('Submission blocked.');
+        return;
+      }
       if (typeof grecaptcha === 'undefined' || typeof grecaptcha.execute === 'undefined') {
           console.error('ReCAPTCHA not loaded yet.');
           alert('ReCAPTCHA is not ready. Please try again in a moment.');


### PR DESCRIPTION
## Summary
- prevent spam by adding hidden inputs to both forms
- hide the honeypot with CSS
- cancel submission in `main.js` if honeypot is filled
- reject requests with non-empty honeypot fields in Cloudflare workers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685033d2b088832bb92d63cceae0d3b9