### PR TITLE
Fix: Align reCAPTCHA site key for Join Us form

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -236,7 +236,7 @@ document.addEventListener("DOMContentLoaded", () => {
           return;
       }
       grecaptcha.ready(() => {
-        grecaptcha.execute('6LfFOV0rAAAAAP2NYL8f1hPyfpsc-MiPx9n02THp', { action: 'join_us_submit' }).then((token) => {
+        grecaptcha.execute('6LfAOV0rAAAAAPBGgn2swZWj5SjANoQ4rUH6XIMz', { action: 'join_us_submit' }).then((token) => {
           console.log('Join Us ReCAPTCHA token:', token);
 
           const name = sanitizeInput(document.getElementById("join-name").value);


### PR DESCRIPTION
The 'Join Us' form was using a different reCAPTCHA site key in js/main.js than the one loaded in index.html and used by the 'Contact Us' form. This mismatch likely caused the 'ERROR for site owner: Invalid dom' error reported by the reCAPTCHA service.

This commit updates the js/main.js file to use the consistent site key (6LfAOV0rAAAAAPBGgn2swZWj5SjANoQ4rUH6XIMz) for the 'Join Us' form's grecaptcha.execute call, aligning it with the key used for initializing reCAPTCHA in index.html. This should resolve the error and ensure reCAPTCHA functions correctly for both forms.