### PR TITLE
feat: Implement interactive modals for Join Us and Contact Us

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -130,3 +130,270 @@
     }
     */
 }
+
+/* Modal Styles */
+.modal-overlay {
+    display: none; /* Changed to flex for testing, normally none */
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    z-index: 1000;
+    /* display: flex; TEMPORARILY flex for testing - switch to none and use JS to toggle */
+    align-items: center;
+    justify-content: center;
+    overflow-y: auto;
+}
+
+.modal-content {
+    background-color: #fff;
+    padding: 20px 30px;
+    border-radius: 8px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+    width: 80%;
+    max-width: 600px;
+    position: relative;
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
+/* JavaScript will toggle this class on the body or modal overlay */
+.modal-open .modal-overlay { /* If you add .modal-open to body */
+    display: flex;
+}
+/* OR, if you toggle a class directly on .modal-overlay itself: */
+.modal-overlay.is-visible {
+    display: flex;
+}
+
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+}
+
+.modal-header h3 {
+    margin: 0;
+    font-size: 1.5em;
+}
+
+.close-modal { /* Assuming this class is used for the close button in HTML */
+    background: none;
+    border: none;
+    font-size: 1.8em;
+    cursor: pointer;
+    color: #888;
+    padding: 0;
+    line-height: 1;
+}
+
+.modal-body {
+    /* No specific styles needed yet, padding is handled by .modal-content */
+}
+
+form .form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+    margin-bottom: 15px;
+}
+
+form .form-cell {
+    display: flex;
+    flex-direction: column;
+}
+
+form .form-cell.full-width {
+    grid-column: span 2;
+}
+
+form label {
+    margin-bottom: 5px;
+    font-weight: bold;
+    font-size: 0.9em;
+    color: #333;
+}
+
+form input[type="text"],
+form input[type="email"],
+form input[type="tel"],
+form input[type="date"],
+form input[type="time"],
+form textarea,
+form select { /* Added select here */
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+    font-size: 1em;
+}
+
+form textarea {
+    resize: vertical;
+}
+
+.honeypot {
+    display: none !important;
+}
+
+/* "Join Us" Modal Specifics - Collapsible Sections */
+.toggle-button {
+    background-color: #f0f0f0;
+    border: 1px solid #ccc;
+    padding: 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+    margin-bottom: 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.dropdown-overlay {
+    border: 1px solid #eee;
+    padding: 15px;
+    border-radius: 4px;
+    margin-top: -10px; /* Overlap slightly with the button */
+    margin-bottom: 15px;
+    background-color: #f9f9f9;
+    display: none; /* by default, JS will toggle */
+}
+
+.checkbox-row {
+    /* display: grid; grid-template-columns: 1fr 1fr; gap: 10px; */
+    /* Using flex for simpler checkbox group layouts, adjust if grid is preferred */
+    display: flex;
+    flex-wrap: wrap; /* Allow wrapping */
+    gap: 10px; /* Space between checkbox items */
+    margin-bottom: 10px; /* Space below the row */
+}
+
+.checkbox-cell { /* Container for each checkbox + label */
+    display: flex; /* Align checkbox and label */
+    align-items: center;
+    /* flex: 1 1 calc(50% - 10px);  Two columns, accounting for gap */
+    /* Or, let them size naturally: */
+}
+
+
+.checkbox-cell label {
+    display: flex;
+    align-items: center;
+    font-weight: normal;
+    font-size: 0.95em;
+    color: #333; /* Ensure label text color */
+    cursor: pointer;
+    margin-bottom: 0; /* Override default label margin */
+}
+
+.checkbox-cell input[type="checkbox"] {
+    margin-right: 8px;
+    width: auto; /* Override form input default width */
+    cursor: pointer;
+}
+
+.done-btn {
+    background-color: #8b5cf6; /* Violet to match FAB */
+    color: white;
+    padding: 8px 15px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    display: block;
+    margin-top: 10px;
+    float: right; /* Align to the right within its container */
+    transition: background-color 0.3s ease;
+}
+
+.done-btn:hover {
+    background-color: #7c3aed; /* Darker violet */
+}
+
+/* Modal Footer & Submit Buttons */
+.modal-footer {
+    text-align: right;
+    border-top: 1px solid #eee;
+    padding-top: 15px;
+    margin-top: 20px;
+}
+
+.submit-button { /* General submit button for modals */
+    background-color: #28a745; /* Green for submit actions */
+    color: white;
+    padding: 12px 25px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1.1em;
+    transition: background-color 0.3s ease;
+}
+
+.submit-button:hover {
+    background-color: #218838; /* Darker green */
+}
+
+/* Responsiveness */
+@media (max-width: 768px) {
+    .modal-content {
+        width: 90%;
+        max-width: none;
+        padding: 20px; /* Adjusted padding for smaller screens */
+        max-height: 85vh; /* Slightly less max height */
+    }
+
+    form .form-row {
+        grid-template-columns: 1fr; /* Stack form cells */
+    }
+
+    form .form-cell.full-width {
+        grid-column: span 1; /* Reset span for single column layout */
+    }
+
+    .modal-header h3 {
+        font-size: 1.3em;
+    }
+
+    .submit-button {
+        padding: 10px 20px;
+        font-size: 1em;
+    }
+
+    .checkbox-cell {
+        /* flex: 1 1 100%; /* Make checkboxes take full width on small screens if needed */
+    }
+}
+
+@media (max-width: 480px) {
+    .modal-content {
+        padding: 15px;
+    }
+    .modal-header h3 {
+        font-size: 1.2em;
+    }
+    form label {
+        font-size: 0.85em;
+    }
+    form input[type="text"],
+    form input[type="email"],
+    form input[type="tel"],
+    form input[type="date"],
+    form input[type="time"],
+    form textarea,
+    form select {
+        padding: 8px;
+        font-size: 0.95em;
+    }
+    .submit-button {
+        padding: 10px 15px;
+        font-size: 0.95em;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 
         <section id="floating-action-buttons">
             <div class="fab-container">
-                <button id="fab-join" class="fab" aria-label="Join Us">
+                <button id="fab-join" class="fab" aria-label="Join Us" data-modal="join-modal">
                     <div class="fab-content-wrapper">
                         <div class="fab-icon-image-area">
                             <i class="fas fa-user-plus"></i>
@@ -49,7 +49,7 @@
                         <span class="fab-text">Join Us</span>
                     </div>
                 </button>
-                <button id="fab-contact" class="fab" aria-label="Contact Us">
+                <button id="fab-contact" class="fab" aria-label="Contact Us" data-modal="contact-modal">
                     <div class="fab-content-wrapper">
                         <div class="fab-icon-image-area">
                             <i class="fas fa-envelope"></i>
@@ -60,7 +60,7 @@
                 <button id="fab-chatbot" class="fab" aria-label="Chatbot AI">
                     <div class="fab-content-wrapper">
                         <div class="fab-icon-image-area">
-                            <i class="fas fa-robot"></i>
+                            <i class="fas fa-user"></i>
                         </div>
                         <span class="fab-text">Chatbot AI</span>
                     </div>
@@ -75,7 +75,187 @@
     </footer>
 
     <div id="modal-container-main">
-        <!-- Dynamically added service modals will go here -->
+        <!-- Join Modal -->
+        <div id="join-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="joinModalTitle">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 id="joinModalTitle" data-en="Join Us" data-es="Únete a Nosotros">Join Us</h3>
+              <button class="close-modal" data-close aria-label="Close">&times;</button>
+            </div>
+            <div class="modal-body">
+              <form id="join-form">
+                <input type="text" name="website" id="honeypot-join" class="honeypot" autocomplete="off">
+                <div class="form-row">
+                  <div class="form-cell">
+                    <label for="join-name" data-en="Name" data-es="Nombre">Name</label>
+                    <input type="text" id="join-name" data-en="Enter your name" data-es="Ingrese su Nombre" placeholder="Enter your name" required>
+                  </div>
+                  <div class="form-cell">
+                    <label for="join-email" data-en="Email" data-es="Correo Electrónico">Email</label>
+                    <input type="email" id="join-email" data-en="Enter your email" data-es="Ingrese su correo electrónico" placeholder="Enter your email" required>
+                  </div>
+                </div>
+                <div class="form-row">
+                  <div class="form-cell">
+                    <label for="join-contact" data-en="Contact Number" data-es="Número de Contacto">Contact Number</label>
+                    <input type="tel" id="join-contact" data-en="Enter your contact number" data-es="Ingrese su número" placeholder="Enter your contact number" required>
+                  </div>
+                  <div class="form-cell">
+                    <label for="join-date" data-en="Date" data-es="Fecha">Date</label>
+                    <input type="date" id="join-date" required>
+                  </div>
+                </div>
+                <div class="form-row">
+                  <div class="form-cell">
+                    <label for="join-time" data-en="Time" data-es="Hora">Time</label>
+                    <input type="time" id="join-time" required>
+                  </div>
+                </div>
+                <div class="form-row">
+                  <div class="form-cell full-width" style="position:relative;">
+                    <label data-en="Employment Type" data-es="Tipo de Empleo">Employment Type</label>
+                    <button type="button" id="employment-type-toggle" class="toggle-button" aria-expanded="false" aria-controls="employment-type-checkboxes">
+                      <span data-en="Work Preference" data-es="Modalidad de trabajo">Work Preference</span>
+                    </button>
+                  </div>
+                </div>
+                <div id="employment-type-checkboxes" class="dropdown-overlay" style="display: none;">
+                  <div class="form-row checkbox-row">
+                    <div class="form-cell checkbox-cell">
+                      <label for="emp-remote">
+                        <span data-en="Remote" data-es="Remoto">Remote</span>
+                        <input type="checkbox" id="emp-remote" name="employment_type" value="Remote">
+                      </label>
+                    </div>
+                    <div class="form-cell checkbox-cell">
+                      <label for="emp-hybrid">
+                        <span data-en="Hybrid" data-es="Híbrido">Hybrid</span>
+                        <input type="checkbox" id="emp-hybrid" name="employment_type" value="Hybrid">
+                      </label>
+                    </div>
+                  </div>
+                  <div class="form-row checkbox-row">
+                    <div class="form-cell checkbox-cell">
+                      <label for="emp-on-site">
+                        <span data-en="On-Site" data-es="En el Sitio">On-Site</span>
+                        <input type="checkbox" id="emp-on-site" name="employment_type" value="On-Site">
+                      </label>
+                    </div>
+                    <div class="form-cell checkbox-cell">
+                      <label for="emp-freelance">
+                        <span data-en="Freelance" data-es="Freelance">Freelance</span>
+                        <input type="checkbox" id="emp-freelance" name="employment_type" value="Freelance">
+                      </label>
+                    </div>
+                  </div>
+                  <div class="form-row checkbox-row">
+                    <div class="form-cell checkbox-cell">
+                      <label for="emp-part-time">
+                        <span data-en="Part-Time" data-es="Medio Tiempo">Part-Time</span>
+                        <input type="checkbox" id="emp-part-time" name="employment_type" value="Part-Time">
+                      </label>
+                    </div>
+                    <div class="form-cell checkbox-cell">
+                      <label for="emp-project-based">
+                        <span data-en="Project-Based" data-es="Por Proyecto">Project-Based</span>
+                        <input type="checkbox" id="emp-project-based" name="employment_type" value="Project-Based">
+                      </label>
+                    </div>
+                  </div>
+                  <div class="form-row checkbox-row">
+                    <div class="form-cell checkbox-cell">
+                      <label for="emp-temporary">
+                        <span data-en="Temporary" data-es="Temporal">Temporary</span>
+                        <input type="checkbox" id="emp-temporary" name="employment_type" value="Temporary">
+                      </label>
+                    </div>
+                    <div class="form-cell checkbox-cell">
+                      <label for="emp-voluntary">
+                        <span data-en="Voluntary / NGO / Non-Profit" data-es="Voluntario / ONG / Sin Fines de Lucro">Voluntary / NGO / Non-Profit</span>
+                        <input type="checkbox" id="emp-voluntary" name="employment_type" value="Voluntary">
+                      </label>
+                    </div>
+                  </div>
+                  <button type="button" id="employment-done" class="done-btn">Done</button>
+                </div>
+
+                <div class="form-row">
+                  <div class="form-cell full-width" style="position:relative;">
+                    <button type="button" id="join-areas-trigger" class="toggle-button" aria-expanded="false" aria-controls="join-areas-options">
+                      Areas of Interest (Optional) <span class="arrow-down">&#9660;</span>
+                    </button>
+                    <div id="join-areas-options" class="dropdown-overlay" style="display: none;">
+                      <label><input type="checkbox" name="join_interest" value="web_development"> Web Development</label>
+                      <label><input type="checkbox" name="join_interest" value="it_support"> IT Support</label>
+                      <label><input type="checkbox" name="join_interest" value="consulting"> Consulting</label>
+                      <label><input type="checkbox" name="join_interest" value="sales"> Sales</label>
+                      <label><input type="checkbox" name="join_interest" value="marketing"> Marketing</label>
+                      <label><input type="checkbox" name="join_interest" value="other"> Other (Please specify in comment)</label>
+                      <button type="button" id="areas-done" class="done-btn">Done</button>
+                    </div>
+                  </div>
+                </div>
+                <div class="form-row">
+                  <div class="form-cell" style="grid-column: span 2;">
+                    <label for="join-comment" data-en="Comment" data-es="Comentario">Comment</label>
+                    <textarea id="join-comment" rows="4" data-en="Tell us about yourself" data-es="Cuéntanos sobre ti" placeholder="Tell us about yourself" required></textarea>
+                  </div>
+                </div>
+                <div class="modal-footer">
+                  <button type="submit" class="submit-button" data-en="Submit" data-es="Enviar">Submit</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+
+        <!-- Contact Modal -->
+        <div id="contact-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="contactModalTitle">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 id="contactModalTitle" data-en="Contact Us" data-es="Contáctenos">Contact Us</h3>
+              <button class="close-modal" data-close aria-label="Close">&times;</button>
+            </div>
+            <div class="modal-body">
+              <form id="contact-form">
+                <input type="text" name="website" id="honeypot-contact" class="honeypot" autocomplete="off">
+                <div class="form-row">
+                  <div class="form-cell">
+                    <label for="contact-name" data-en="Name" data-es="Nombre">Name</label>
+                    <input type="text" id="contact-name" data-en="Enter your name" data-es="Ingrese su Nombre" placeholder="Enter your name" required>
+                  </div>
+                  <div class="form-cell">
+                    <label for="contact-email" data-en="Email" data-es="Correo Electrónico">Email</label>
+                    <input type="email" id="contact-email" data-en="Enter your email" data-es="Ingrese su correo electrónico" placeholder="Enter your email" required>
+                  </div>
+                </div>
+                <div class="form-row">
+                  <div class="form-cell">
+                    <label for="contact-number" data-en="Contact Number" data-es="Número de Contacto">Contact Number</label>
+                    <input type="tel" id="contact-number" data-en="Enter your contact number" data-es="Ingrese su número" placeholder="Enter your contact number" required>
+                  </div>
+                  <div class="form-cell">
+                    <label for="contact-date" data-en="Preferred Date" data-es="Fecha Preferida">Preferred Date</label>
+                    <input type="date" id="contact-date" required>
+                  </div>
+                </div>
+                <div class="form-row">
+                  <div class="form-cell">
+                    <label for="contact-time" data-en="Preferred Time" data-es="Hora Preferida">Preferred Time</label>
+                    <input type="time" id="contact-time" required>
+                  </div>
+                  <div class="form-cell">
+                    <label for="contact-comments" data-en="Comments" data-es="Comentarios">Comments</label>
+                    <textarea id="contact-comments" rows="4" data-en="What service are you interested in?" data-es="¿En qué servicio está interesado?" placeholder="What service are you interested in?" required></textarea>
+                  </div>
+                </div>
+                <div class="modal-footer">
+                  <button type="submit" class="submit-button" data-en="Send" data-es="Enviar">Send</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
     </div>
 
     <script src="js/script.js" defer></script>

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,206 @@
+document.addEventListener('DOMContentLoaded', () => {
+
+    // --- Modal Functionality ---
+    const fabButtons = document.querySelectorAll('.fab[data-modal]');
+    const modalOverlays = document.querySelectorAll('.modal-overlay'); // Get all overlays
+    // Note: Close buttons are specific to each modal, so we select them when opening or attach listeners more generally.
+
+    fabButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            const modalId = button.getAttribute('data-modal');
+            const modal = document.getElementById(modalId);
+
+            if (modal) {
+                // Find the parent .modal-overlay if modalId is the content div
+                // The modal structure is <div id="join-modal" class="modal"> which is inside <div class="modal-overlay">
+                // So, if the `data-modal` attribute directly points to "join-modal" (the content),
+                // we need to find its parent that is the actual overlay to show/hide.
+                // However, my CSS has .modal-overlay as the element to hide/show, and the HTML has <div id="join-modal" class="modal">.
+                // The CSS for .modal-overlay has display:none/flex. The actual modal content (e.g. #join-modal) is a child.
+                // So, the target for display change should be the element with class .modal-overlay that contains #modalId
+
+                // Let's assume the structure is:
+                // <div class="modal-overlay" id="overlay-for-join-modal"> <div id="join-modal" class="modal-content">...</div> </div>
+                // Or, as per current HTML:
+                // <div id="join-modal" class="modal"> -> this IS the overlay in the new HTML structure from previous steps.
+                // <div id="join-modal" class="modal"> is what needs display:flex. Let's re-verify HTML.
+                // The HTML generated was: <div id="join-modal" class="modal">...</div> and <div id="contact-modal" class="modal">...</div>
+                // The CSS has .modal { display:none } by default (implicitly via .modal-overlay if that was the case, but it's distinct now)
+                // Let's adjust to target the modal directly, assuming .modal is what needs to be displayed.
+                // The CSS has .modal-overlay { display: none; ... display: flex; }
+                // The HTML has <div id="join-modal" class="modal">, NOT <div id="join-modal" class="modal-overlay">
+                // The user-provided HTML for modals was <div id="join-modal" class="modal">.
+                // My previous step put these inside <div id="modal-container-main">.
+                // The CSS I wrote targets `.modal-overlay` for display toggling.
+                // This means the HTML structure should be `<div class="modal-overlay" id="join-modal-overlay"><div id="join-modal" class="modal-content">...</div></div>`
+                // But the HTML committed is `<div id="join-modal" class="modal">...</div>`.
+                // This is a mismatch. The JS should target `document.getElementById(modalId)` and this element should have `class="modal-overlay"`.
+
+                // Given the current HTML structure: <div id="join-modal" class="modal"> and CSS targets .modal-overlay
+                // I will assume for now that the element with ID (e.g., "join-modal") IS the one to show/hide.
+                // And that its class list should include "modal-overlay" for the CSS to apply correctly.
+                // Or, the CSS selector should be `.modal` instead of `.modal-overlay`.
+                // The prompt for CSS said: "Create styles for .modal-overlay" and "A class like .modal-open ... will change display:flex on .modal-overlay"
+                // The HTML provided by user: <div id="join-modal" class="modal">
+                // The HTML I integrated: <div id="join-modal" class="modal"> inside #modal-container-main
+
+                // Let's stick to the current CSS which uses .modal-overlay for display toggling.
+                // The HTML for modals should be <div id="join-modal" class="modal-overlay">...</div> or have this class added.
+                // For now, I will assume `modal` element found by ID is the one to show/hide.
+                // This will only work if `id="join-modal"` element *also* has `class="modal-overlay"`.
+                // Let's assume the elements "join-modal" and "contact-modal" are the overlays themselves.
+                // The CSS was written for `.modal-overlay`. The HTML for the modals is `<div id="contact-modal" class="modal">`.
+                // This means that for the JS to work with the CSS, the modal elements should have the class `modal-overlay`.
+                // The subtask was to integrate user-provided HTML. The user HTML is `<div id="join-modal" class="modal">`.
+                // This implies the CSS should probably operate on `.modal` not `.modal-overlay` for the main show/hide.
+                // Or, the `data-modal` attribute should point to an ID of a `modal-overlay` element.
+
+                // Simplest path: Assume `document.getElementById(modalId)` IS the overlay.
+                // This means the HTML `id="join-modal"` should have `class="modal-overlay"`.
+                // Let's check the HTML structure committed earlier.
+                // index.html has: <div id="join-modal" class="modal">.
+                // CSS has: .modal-overlay { display: none; ... }
+                // This will not work as is. The element with ID "join-modal" does not have class "modal-overlay".
+
+                // EITHER:
+                // 1. JS changes style of `document.getElementById(modalId)` (which is <div class="modal">) AND CSS is changed from .modal-overlay to .modal
+                // 2. HTML is changed so that <div id="join-modal" class="modal modal-overlay">
+                // 3. JS finds the modal by ID, then finds its parent .modal-overlay (if structure was nested, which it isn't directly)
+
+                // Given the problem constraints, modifying CSS or HTML is out of scope for *this* script writing subtask.
+                // The script must work with the *current* HTML and CSS.
+                // The current CSS expects `.modal-overlay` to be the element whose display is toggled.
+                // The current HTML has `<div id="join-modal" class="modal">`.
+                // This means the FAB `data-modal` attribute should point to an element that has the `modal-overlay` class.
+                // The problem says "Paste the HTML for the 'Join Us' modal...". This HTML is `<div id="join-modal" class="modal">`.
+                // This implies this *is* the modal.
+                // The most robust way for this JS, without changing other files, is to assume `modalId` refers to the modal content,
+                // and we need a way to get to its overlay.
+                // However, the provided HTML for modals ARE the top-level containers for each modal.
+
+                // Let's assume `document.getElementById(modalId)` is the element that should be shown/hidden.
+                // And it should have the necessary class for styling (i.e. it should be `.modal-overlay` or CSS should target `.modal`)
+                // The CSS has `.modal-overlay { display: flex; ... }` and also `.modal-content { ... }`
+                // The HTML has `<div id="join-modal" class="modal"> <div class="modal-content"> ... </div> </div>`
+                // This means the element with `id="join-modal"` is intended to be the overlay.
+                // So it should have the class `modal-overlay`.
+                // If it doesn't, the JS setting display on it will work, but the CSS for background etc. won't apply unless it also has modal-overlay class.
+
+                // For the purpose of this JS, let's assume `document.getElementById(modalId)` is the element to show.
+                // The CSS currently defines `.modal-overlay` for display toggling.
+                // The elements `join-modal` and `contact-modal` have class `modal`.
+                // This is a conflict.
+                // I will write the JS to target `document.getElementById(modalId)` and set its display.
+                // This implies that for this to work visually as intended by the CSS,
+                // `<div id="join-modal" class="modal">` should have been `<div id="join-modal" class="modal modal-overlay">`.
+                // I will proceed with the JS targeting `document.getElementById(modalId)` for display changes.
+
+                if (modal) { // modal is <div id="xxx-modal" class="modal">
+                    modal.style.display = 'flex'; // This assumes the .modal class (or the ID selector) is styled for this.
+                                                 // OR that this element *also* has .modal-overlay class.
+                                                 // Given CSS is .modal-overlay { display:flex }, this will only work if id="join-modal" also has class="modal-overlay"
+                    document.body.style.overflow = 'hidden';
+                }
+            }
+        });
+    });
+
+    // The 'modalOverlays' variable correctly selects all elements with class 'modal-overlay'.
+    // These are the elements that should be hidden/shown.
+    // Their IDs (e.g., "join-modal") are used by fabButtons to open them.
+
+    modalOverlays.forEach(overlay => {
+        // Close Modal Logic (Overlay Click)
+        overlay.addEventListener('click', (event) => {
+            // Ensure the click is on the overlay background itself, not on its children (modal-content).
+            if (event.target === overlay) {
+                overlay.style.display = 'none';
+                document.body.style.overflow = '';
+            }
+        });
+
+        // Close Modal Logic (Close Button inside this specific overlay)
+        // HTML was updated to use <button class="close-modal">
+        const closeButton = overlay.querySelector('.close-modal');
+        if (closeButton) {
+            closeButton.addEventListener('click', () => {
+                overlay.style.display = 'none';
+                document.body.style.overflow = '';
+            });
+        }
+    });
+
+
+    // --- "Join Us" Modal - Internal Dropdown Functionality ---
+
+    const setupDropdownToggle = (toggleButtonId, contentElementId, doneButtonId) => {
+        const toggleButton = document.getElementById(toggleButtonId);
+        const contentElement = document.getElementById(contentElementId);
+        const doneButton = doneButtonId ? document.getElementById(doneButtonId) : null;
+
+        if (toggleButton && contentElement) {
+            // Set initial state based on CSS or explicitly hide
+            contentElement.style.display = 'none'; // Ensure it's hidden initially
+            toggleButton.setAttribute('aria-expanded', 'false');
+
+            toggleButton.addEventListener('click', (e) => {
+                e.preventDefault(); // Prevent any default action if it's a button in a form
+                const isExpanded = contentElement.style.display === 'block' || contentElement.style.display === 'grid' || contentElement.style.display === 'flex';
+                contentElement.style.display = isExpanded ? 'none' : 'block';
+                toggleButton.setAttribute('aria-expanded', String(!isExpanded));
+            });
+
+            if (doneButton) {
+                doneButton.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    contentElement.style.display = 'none';
+                    toggleButton.setAttribute('aria-expanded', 'false');
+                });
+            }
+        }
+    };
+
+    // Employment Type Dropdown (in "Join Us" modal)
+    // IDs from user-provided HTML:
+    // employment-type-toggle (button for "Work Preference")
+    // employment-type-checkboxes (div containing checkboxes for "Work Preference")
+    // employment-done (button "DONE" for "Work Preference")
+    setupDropdownToggle('employment-type-toggle', 'employment-type-checkboxes', 'employment-done');
+
+    // Areas of Interest Dropdown (in "Join Us" modal)
+    // IDs from user-provided HTML:
+    // join-areas-trigger (button for "Areas of Interest")
+    // join-areas-options (div containing checkboxes for "Areas of Interest")
+    // areas-done (button "DONE" for "Areas of Interest")
+    setupDropdownToggle('join-areas-trigger', 'join-areas-options', 'areas-done');
+
+
+    // --- Form Submission Handling (Basic) ---
+    const joinForm = document.getElementById('join-form');
+    if (joinForm) {
+        joinForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+            console.log('Join form submitted (data prevented from sending)');
+            // Optionally, close the modal after submission attempt
+            const modal = joinForm.closest('.modal-overlay');
+            if (modal) {
+                 modal.style.display = 'none';
+                 document.body.style.overflow = '';
+            }
+        });
+    }
+
+    const contactForm = document.getElementById('contact-form');
+    if (contactForm) {
+        contactForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+            console.log('Contact form submitted (data prevented from sending)');
+            const modal = contactForm.closest('.modal-overlay');
+            if (modal) {
+                modal.style.display = 'none';
+                document.body.style.overflow = '';
+            }
+        });
+    }
+
+});


### PR DESCRIPTION
This commit introduces several enhancements to the Floating Action Buttons (FABs) and related user interaction:

1.  **Join Us Modal:**
    *   The "Join Us" FAB now triggers a comprehensive pop-up modal.
    *   This modal includes a form for applicants with fields for name, email, contact info, date, and time.
    *   Features two internal collapsible (dropdown) sections:
        *   "Employment Type": Allows users to select multiple work preferences (Remote, Hybrid, On-Site, etc.) via checkboxes. A "DONE" button closes this section.
        *   "Areas of Interest": Allows users to select areas of interest. A "DONE" button closes this section.
    *   Checkboxes within these sections are aligned for clarity.
    *   A final button to send the form is present.

2.  **Contact Us Modal:**
    *   The "Contact Us" FAB now triggers a pop-up modal with a contact form.
    *   Includes fields for name, email, contact number, preferred date/time, and comments.

3.  **Chatbot FAB Update:**
    *   The Chatbot FAB icon has been changed from a robot (`fas fa-robot`) to a user icon (`fas fa-user`), while retaining the "Chatbot AI" text.

4.  **Modal Functionality & Styling:**
    *   All modals are designed to appear centered on the screen.
    *   Modals are responsive and adapt to various screen sizes.
    *   Modals can be closed by clicking an "X" button or by clicking on the semi-transparent overlay.
    *   Form submissions within modals are currently handled client-side (preventing default page reload and closing the modal).

These changes were implemented by:
- Updating `index.html` with the new modal structures.
- Adding CSS rules to `css/style.css` for modal appearance, layout, internal dropdowns, and responsiveness.
- Writing JavaScript in `js/script.js` to manage modal visibility, internal dropdown toggling, and basic form handling.