### PR TITLE
fix: Position footer at bottom-center of screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -280,3 +280,21 @@
 .language-switch input:checked + .slider .lang-indicator.es {
     opacity: 1;
 }
+
+/* Footer Styling */
+footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    padding-bottom: 5px; /* This acts as the margin from the bottom edge of its content */
+    /* background-color: var(--body-bg-color); /* Optional: give it a slight background to ensure readability over .glow-effect if it's very active near bottom */
+    z-index: 990; /* Below FABs (999) but above general content and glow effect (-1) */
+}
+
+footer p {
+    margin: 0; /* Remove default paragraph margin */
+    font-size: 0.8rem;
+    color: var(--text-color-subtle); /* Use theme variable for text color */
+}


### PR DESCRIPTION
I've updated the CSS for your site's footer with the following changes:
- The footer is now fixed at the bottom of the viewport.
- The text content within the footer is centered.
- There's a 5px distance from the bottom edge of the viewport to the footer text baseline, achieved using padding.
- The footer text color remains theme-aware through your existing CSS variables.
- The footer text content continues to be language-aware through your existing translation system.
- I've adjusted the z-index to ensure proper layering with other fixed elements, such as FABs.