### PR TITLE
I've made some improvements to the 'Join Us' modal's HTML, JavaScript…

### DIFF
--- a/css/join-us.css
+++ b/css/join-us.css
@@ -61,29 +61,33 @@
 .form-section {
     margin-bottom: 20px;
     /* The form sections will now naturally be contained by .modal-content's width */
+    /* Add some padding to the bottom of the section if it's not the last one,
+       or if preferred, rely on margins of elements within.
+       For now, relying on element margins. */
 }
 
-.form-section h3 {
+/* Specific styling for elements within the Join Us modal form sections */
+#join-modal .form-section h3 {
     margin-top: 0;
-    margin-bottom: 15px;
+    margin-bottom: 20px; /* Increased bottom margin for section title */
     color: var(--text-color-main);
     font-size: 1.25em;
 }
 
-label {
+#join-modal .form-section label {
     display: block;
-    margin-bottom: 8px;
+    margin-bottom: 8px; /* Spacing below label */
     color: var(--text-color-subtle);
     font-weight: bold;
 }
 
-input[type="text"],
-input[type="email"],
-input[type="tel"],
-select {
+#join-modal .form-section input[type="text"],
+#join-modal .form-section input[type="email"],
+#join-modal .form-section input[type="tel"],
+#join-modal .form-section select {
     width: 100%;
     padding: 12px;
-    margin-bottom: 15px;
+    margin-bottom: 18px; /* Increased spacing below input/select fields */
     border: 1px solid var(--card-border-color);
     background-color: var(--input-bg-color, var(--body-bg-color));
     color: var(--text-color-main);
@@ -92,16 +96,25 @@ select {
     font-size: 1em;
 }
 
-input[type="text"]:focus,
-input[type="email"]:focus,
-input[type="tel"]:focus,
-select:focus {
+#join-modal .form-section input[type="text"]:focus,
+#join-modal .form-section input[type="email"]:focus,
+#join-modal .form-section input[type="tel"]:focus,
+#join-modal .form-section select:focus {
     border-color: var(--accent-color);
     box-shadow: 0 0 0 2px var(--accent-color-transparent);
     outline: none;
 }
 
+/* General button styles - these might be too broad if .modal-content has other buttons.
+   It's better to scope them if they are specific to the form, or ensure they are general enough.
+   The existing 'button' rule is fairly generic.
+   Adding specific margin-top for form buttons. */
 
+#join-modal .form-section button { /* Targets all buttons within form sections */
+    margin-top: 10px; /* Space above buttons */
+}
+
+/* General button styling (keeping existing global button rules if they apply) */
 button {
     background-color: var(--fab-bg-color);
     color: var(--fab-text-color);
@@ -118,15 +131,26 @@ button:hover {
     background-color: var(--fab-hover-bg-color);
 }
 
-button[type="button"] {
+/* This rule specifically targets type="button" which is often used for prev/next */
+#join-modal .form-section button[type="button"] {
     background-color: var(--button-secondary-bg-color, var(--card-border-color));
     color: var(--button-secondary-text-color, var(--text-color-main));
 }
 
-button[type="button"]:hover {
+#join-modal .form-section button[type="button"]:hover {
     background-color: var(--button-secondary-hover-bg-color, var(--header-bg-color));
 }
 
-button + button {
+/* Submit button might have primary action styling, ensure it's distinct if needed */
+#join-modal .form-section button[type="submit"] {
+    background-color: var(--fab-bg-color); /* Ensure submit uses primary color */
+    color: var(--fab-text-color);
+}
+#join-modal .form-section button[type="submit"]:hover {
+    background-color: var(--fab-hover-bg-color);
+}
+
+
+button + button { /* This handles adjacent buttons like Prev + Next */
     margin-left: 10px;
 }

--- a/index.html
+++ b/index.html
@@ -86,25 +86,25 @@
         <!-- Dynamically added service modals will go here -->
         <div id="join-modal" class="modal opslight-service-modal" style="display: none;" role="dialog" aria-modal="true" aria-labelledby="join-modal-title">
             <div class="modal-content">
-                <span class="close-btn">&times;</span>
+                <button type="button" class="close-btn" aria-label="Close" data-aria-label-translate-key="joinModal.closeButtonAriaLabel">&times;</button>
                 <h2 id="join-modal-title" data-translate-key="joinModal.title">Membership Application</h2>
                 <form id="multiStepForm">
                     <div class="form-section" id="section1">
                         <h3 data-translate-key="joinModal.section1.title">Personal Information</h3>
                         <label for="fullName" data-translate-key="joinModal.section1.fullNameLabel">Full Name:</label>
-                        <input type="text" id="fullName" name="fullName" required data-placeholder-translate-key="joinModal.section1.fullNamePlaceholder"><br><br>
+                        <input type="text" id="fullName" name="fullName" required data-placeholder-translate-key="joinModal.section1.fullNamePlaceholder">
                         <label for="email" data-translate-key="joinModal.section1.emailLabel">Email:</label>
-                        <input type="email" id="email" name="email" required data-placeholder-translate-key="joinModal.section1.emailPlaceholder"><br><br>
-                        <button type="button" onclick="nextSection('section2')" data-translate-key="joinModal.button.next">Next</button>
+                        <input type="email" id="email" name="email" required data-placeholder-translate-key="joinModal.section1.emailPlaceholder">
+                        <button type="button" class="join-form-next-btn" data-translate-key="joinModal.button.next">Next</button>
                     </div>
                     <div class="form-section" id="section2" style="display:none;">
                         <h3 data-translate-key="joinModal.section2.title">Contact Details</h3>
                         <label for="phone" data-translate-key="joinModal.section2.phoneLabel">Phone Number:</label>
-                        <input type="tel" id="phone" name="phone" data-placeholder-translate-key="joinModal.section2.phonePlaceholder"><br><br>
+                        <input type="tel" id="phone" name="phone" data-placeholder-translate-key="joinModal.section2.phonePlaceholder">
                         <label for="address" data-translate-key="joinModal.section2.addressLabel">Address:</label>
-                        <input type="text" id="address" name="address" data-placeholder-translate-key="joinModal.section2.addressPlaceholder"><br><br>
-                        <button type="button" onclick="prevSection('section1')" data-translate-key="joinModal.button.previous">Previous</button>
-                        <button type="button" onclick="nextSection('section3')" data-translate-key="joinModal.button.next">Next</button>
+                        <input type="text" id="address" name="address" data-placeholder-translate-key="joinModal.section2.addressPlaceholder">
+                        <button type="button" class="join-form-prev-btn" data-translate-key="joinModal.button.previous">Previous</button>
+                        <button type="button" class="join-form-next-btn" data-translate-key="joinModal.button.next">Next</button>
                     </div>
                     <div class="form-section" id="section3" style="display:none;">
                         <h3 data-translate-key="joinModal.section3.title">Membership Preferences</h3>
@@ -113,10 +113,10 @@
                             <option value="basic" data-translate-key="joinModal.section3.membershipType.basic">Basic</option>
                             <option value="premium" data-translate-key="joinModal.section3.membershipType.premium">Premium</option>
                             <option value="vip" data-translate-key="joinModal.section3.membershipType.vip">VIP</option>
-                        </select><br><br>
+                        </select>
                         <label for="referral" data-translate-key="joinModal.section3.referralLabel">How did you hear about us?</label>
-                        <input type="text" id="referral" name="referral" data-placeholder-translate-key="joinModal.section3.referralPlaceholder"><br><br>
-                        <button type="button" onclick="prevSection('section2')" data-translate-key="joinModal.button.previous">Previous</button>
+                        <input type="text" id="referral" name="referral" data-placeholder-translate-key="joinModal.section3.referralPlaceholder">
+                        <button type="button" class="join-form-prev-btn" data-translate-key="joinModal.button.previous">Previous</button>
                         <button type="submit" data-translate-key="joinModal.button.submit">Submit</button>
                     </div>
                 </form>

--- a/js/join-us.js
+++ b/js/join-us.js
@@ -33,65 +33,83 @@ function updateJoinUsModalLanguage() {
 document.addEventListener('DOMContentLoaded', () => {
     const modal = document.getElementById('join-modal');
     const fabJoinBtn = document.getElementById('fab-join');
-    const span = document.querySelector('#join-modal .close-btn');
+    const closeButton = document.querySelector('#join-modal .close-btn'); // Corrected variable name from span to closeButton
+
+    // Functions for multi-step form navigation
+    function showSection(sectionId) {
+        sections.forEach(id => {
+            const sectionElement = document.getElementById(id);
+            if (sectionElement) {
+                sectionElement.style.display = (id === sectionId) ? 'block' : 'none';
+            }
+        });
+    }
+
+    function nextJoinSection() {
+        currentSection++;
+        if (currentSection >= sections.length) {
+            currentSection = sections.length - 1; // Stay on the last section if trying to go beyond
+        }
+        showSection(sections[currentSection]);
+    }
+
+    function prevJoinSection() {
+        currentSection--;
+        if (currentSection < 0) {
+            currentSection = 0; // Stay on the first section if trying to go before
+        }
+        showSection(sections[currentSection]);
+    }
 
     if (modal) {
-        // Initial language setup for any dynamic elements (if any)
         updateJoinUsModalLanguage();
-
-        // Listen for language changes from the global switcher
         document.addEventListener('languageChanged', updateJoinUsModalLanguage);
 
         if (fabJoinBtn) {
             fabJoinBtn.onclick = function() {
                 modal.style.display = 'block';
-            }
+                currentSection = 0; // Reset to the first section when opening
+                showSection(sections[currentSection]);
+            };
         }
 
-        if (span) {
-            span.onclick = function() {
+        if (closeButton) {
+            closeButton.onclick = function() {
                 modal.style.display = 'none';
-            }
+            };
         }
 
         window.onclick = function(event) {
             if (event.target == modal) {
                 modal.style.display = 'none';
             }
-        }
-        showSection(sections[currentSection]); // Initialize the first section if modal exists
+        };
+
+        // Attach event listeners to next/prev buttons
+        const nextButtons = modal.querySelectorAll('.join-form-next-btn');
+        nextButtons.forEach(button => {
+            button.addEventListener('click', nextJoinSection);
+        });
+
+        const prevButtons = modal.querySelectorAll('.join-form-prev-btn');
+        prevButtons.forEach(button => {
+            button.addEventListener('click', prevJoinSection);
+        });
+
+        showSection(sections[currentSection]); // Initialize the first section
     } else {
         // console.error("Modal with ID 'join-modal' not found in join-us.js.");
     }
-});
 
-function showSection(sectionId) {
-    sections.forEach(id => {
-        document.getElementById(id).style.display = (id === sectionId) ? 'block' : 'none';
-    });
-}
-
-function nextSection(sectionId) {
-    currentSection = sections.indexOf(sectionId);
-    if (currentSection < sections.length) {
-        showSection(sectionId);
-    }
-}
-
-function prevSection(sectionId) {
-    currentSection = sections.indexOf(sectionId);
-    if (currentSection >= 0) {
-        showSection(sectionId);
-    }
-}
-
-document.getElementById('multiStepForm').addEventListener('submit', function(event) {
-    event.preventDefault();
-    // Form submission logic here
-    const successMessage = window.getTranslatedText ? window.getTranslatedText('joinModal.alert.formSubmittedSuccess') : 'Form submitted successfully!';
-    alert(successMessage);
-    const modalToClose = document.getElementById('join-modal');
-    if (modalToClose) {
-        modalToClose.style.display = 'none';
+    const multiStepForm = document.getElementById('multiStepForm');
+    if (multiStepForm) {
+        multiStepForm.addEventListener('submit', function(event) {
+            event.preventDefault();
+            const successMessage = window.getTranslatedText ? window.getTranslatedText('joinModal.alert.formSubmittedSuccess') : 'Form submitted successfully!';
+            alert(successMessage);
+            if (modal) { // Ensure modal is defined before trying to hide it
+                modal.style.display = 'none';
+            }
+        });
     }
 });

--- a/js/language-switcher.js
+++ b/js/language-switcher.js
@@ -74,7 +74,8 @@ document.addEventListener('DOMContentLoaded', () => {
             "joinModal.section3.referralLabel": "How did you hear about us?",
             "joinModal.section3.referralPlaceholder": "Tell us how you found us",
             "joinModal.button.submit": "Submit",
-            "joinModal.alert.formSubmittedSuccess": "Form submitted successfully!"
+            "joinModal.alert.formSubmittedSuccess": "Form submitted successfully!",
+            "joinModal.closeButtonAriaLabel": "Close Join Us Form"
         },
         es: {
             "header.main": "SPO",
@@ -145,7 +146,8 @@ document.addEventListener('DOMContentLoaded', () => {
             "joinModal.section3.referralLabel": "¿Cómo te enteraste de nosotros?",
             "joinModal.section3.referralPlaceholder": "Cuéntanos cómo nos encontraste",
             "joinModal.button.submit": "Enviar",
-            "joinModal.alert.formSubmittedSuccess": "¡Formulario enviado con éxito!"
+            "joinModal.alert.formSubmittedSuccess": "¡Formulario enviado con éxito!",
+            "joinModal.closeButtonAriaLabel": "Cerrar Formulario Únete"
         }
     };
 
@@ -179,6 +181,17 @@ document.addEventListener('DOMContentLoaded', () => {
                 element.setAttribute('placeholder', translation);
             } else {
                 // console.warn(`Placeholder translation key not found: ${key} for language: ${currentLanguage}`);
+            }
+        });
+
+        // Handle aria-labels
+        document.querySelectorAll('[data-aria-label-translate-key]').forEach(element => {
+            const key = element.getAttribute('data-aria-label-translate-key');
+            const translation = translations[currentLanguage]?.[key]; // Optional chaining
+            if (translation !== undefined) {
+                element.setAttribute('aria-label', translation);
+            } else {
+                // console.warn(`ARIA label translation key not found: ${key} for language: ${currentLanguage}`);
             }
         });
     }


### PR DESCRIPTION
…, and CSS.

Here's a summary of the changes:

HTML (`index.html`):
- I've updated the close button to be a proper `<button>` element with a translatable `aria-label` for better accessibility.
- I removed `<br>` tags previously used for layout; spacing is now managed by CSS.

JavaScript (`js/join-us.js`):
- The form navigation functions (`nextJoinSection`, `prevJoinSection`) are now more self-contained. They use the `currentSection` index instead of arguments passed from HTML and include boundary checks.
- I've removed inline `onclick` event handlers for navigation buttons from the HTML and replaced them with event listeners attached in JavaScript.
- Navigation functions and `showSection` are now scoped within the `DOMContentLoaded` event listener, which helps reduce global scope usage.
- The modal will now automatically reset to display the first section when you open it.
- I added a check to ensure `multiStepForm` exists before attaching its submit event listener.

CSS (`css/join-us.css`):
- I've added `margin-bottom` to input fields and select elements, and `margin-top` to buttons within form sections. This ensures proper spacing after removing the `<br>` tags.

Internationalization (`js/language-switcher.js`):
- I added translation keys for the new `aria-label` of the close button.
- I've enhanced `loadTranslations()` in `language-switcher.js` to correctly process `data-aria-label-translate-key` attributes.

These updates should make the modal more accessible, easier to maintain, and more robust.