### PR TITLE
fix: Refine floating icon alignment and theme toggle border

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,6 +5,7 @@
     right: 20px;
     display: flex;
     flex-direction: column; /* Stack icons vertically */
+    align-items: flex-end; /* Align items to the end (right for LTR, bottom if flex-direction was row) */
     gap: 10px; /* Space between buttons */
     z-index: 999; /* Ensure they are above most other content */
 }
@@ -322,7 +323,7 @@ footer p {
 .header-toggle-btn {
     background-color: var(--card-bg-color);
     color: var(--text-color-subtle);
-    border: 1px solid var(--card-border-color);
+    border: 1px solid var(--text-color-subtle);
     padding: 0.5rem 0.8rem;
     border-radius: 4px;
     cursor: pointer;


### PR DESCRIPTION
Implements UI refinements based on your feedback:

1.  **Floating Icon Alignment:**
    - Updated `css/style.css` for the `.fab-container`. Added `align-items: flex-end;` to ensure all floating action buttons are aligned to the right edge of their vertical column.

2.  **Theme Toggle Button Border:**
    - Modified the `.header-toggle-btn` style in `css/style.css`.
    - Changed the `border-color` to use `var(--text-color-subtle)` (from `var(--card-border-color)`) to ensure the button's rectangular "edge" is more consistently visible across themes. The text remains without brackets as per previous update.