### PR TITLE
fix: Remove broken link to missing js/script.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,6 @@
             </div>
         </div>
     </div>
-    <script src="js/script.js" defer></script>
     <script src="js/join-us.js" defer></script>
     <script src="js/cursor-glow-effect.js" defer></script>
     <script src="js/dynamic-modal-manager.js" defer></script>


### PR DESCRIPTION
Addresses diagnostics for modals failing to open:
- Removed a `<script src="js/script.js" defer></script>` tag from `index.html` because the file `js/script.js` was found to be missing from the repository. This prevents a 404 error in the browser console.

Other diagnostic steps in this cycle (re-verifying modal HTML, analyzing JS execution paths for modal display, checking for CSS overrides) did not identify other specific code errors that would definitively explain a total failure of all modals to open, assuming previous reports about HTML integrity and JS logic were accurate.

If modal opening issues persist, further client-side debugging (cache clearing, console error analysis, CSS inspection via dev tools) is recommended.