### PR TITLE
Fix: Ensure 'Join Us' modal appears and resolve container overflows

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,7 +25,7 @@
     transition: background-color 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
     padding: 0; /* Remove padding if content wrapper handles it */
     position: relative; /* Keep for potential ::before/::after effects or absolute text */
-    overflow: visible; /* Allow hover text to show if it's outside */
+    overflow: hidden; /* Prevent content from spilling out */
 }
 
 .fab:hover {
@@ -474,6 +474,8 @@ footer p {
 .standard-modal-content {
     padding: 24px;
     overflow-y: auto; /* Allow content to scroll if it exceeds modal height */
+    overflow-x: hidden; /* Prevent horizontal overflow */
+    overflow-wrap: break-word; /* Allow long words to break and wrap */
     flex-grow: 1; /* Allow content to take available space */
     color: #333333;
     line-height: 1.6;

--- a/js/script.js
+++ b/js/script.js
@@ -185,6 +185,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (joinModal) joinModal.triggerElement = joinModalTriggerElement;
 
         showJoinModalSection('join-modal-section-1'); // Reset to the first section
+        if (modalContainerMain) {
+            modalContainerMain.style.display = 'flex'; // Ensure the main container is visible
+        }
         joinModal.style.display = 'flex';
         // document.body.style.overflow = 'hidden'; // Let dynamic-modal-manager handle body overflow
 


### PR DESCRIPTION
- Modified js/script.js to ensure the '#modal-container-main' is displayed when the 'Join Us' modal is triggered. This resolves an issue where the modal would not appear if its parent container was hidden.
- Updated css/style.css to address content overflow issues:
  - Set 'overflow: hidden' for '.fab' elements to prevent internal content (icons/text) from spilling outside the button's boundaries.
  - Added 'overflow-x: hidden' and 'overflow-wrap: break-word' to '.standard-modal-content' to prevent horizontal overflow and ensure long text wraps within modals.