### PR TITLE
Refactor: Implement two-column layout for Join Us form

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -266,9 +266,38 @@ main {
     color: var(--button-secondary-text-color);
     font-size: 0.8rem;
 }
-#join-us-modal .lang-toggle:hover {
-    background-color: var(--button-secondary-hover-bg-color);
+/* #join-us-modal .lang-toggle:hover { */ /* Removed as the element is gone */
+    /* background-color: var(--button-secondary-hover-bg-color); */
+/* } */
+
+/* Join Us Modal - Two Column Layout */
+#join-us-modal .form-columns {
+    display: flex;
+    gap: 1.5rem; /* Gap between the two main columns */
+    margin-bottom: 1.5rem; /* Space before the form footer */
 }
+
+#join-us-modal .form-column {
+    flex: 1; /* Each column takes equal width */
+    display: flex;
+    flex-direction: column;
+    gap: 1rem; /* Gap between items within a column */
+}
+
+/* Ensure form-row within a column spans full width if it's the only direct child of form-column for layout purposes */
+/* This specifically targets the Name/Email/Phone group and the Textarea group */
+#join-us-modal .form-column > .form-row {
+    display: flex; /* Changed from grid to flex for simpler stacking of label/input */
+    flex-direction: column;
+    gap: 0.5rem; /* Gap between label and input, and between input groups */
+}
+
+/* Adjusting the original rule for Name/Email/Phone to fit the new structure */
+/* This rule might need to be removed or adjusted if it conflicts. */
+/* #join-us-modal #join-form > .form-row:first-child { ... } */
+/* For now, we'll let the new .form-column > .form-row handle it. */
+/* The individual label/input pairs will stack vertically by default within their parent .form-row */
+
 
 /* Form Styling (common for Join Us, Contact Us) */
 .form-section {
@@ -425,8 +454,12 @@ textarea {
 }
 
 /* Ensure buttons within modals are contained */
-.modal-content .form-footer, .modal-content .form-section {
+.modal-content .form-section { /* form-footer removed from here to allow its own styling */
     overflow: hidden; /* Prevents internal button hover effects from spilling */
+}
+#join-us-modal .form-footer {
+    text-align: center; /* Center the submit button */
+    margin-top: 1rem; /* Add some space above the footer */
 }
 .modal-content .submit-button, .modal-content .accept-btn, .modal-content .edit-btn {
     /* No specific changes needed if padding/margins are correct */
@@ -606,15 +639,22 @@ footer {
         font-size: 1.3rem;
     }
     /* Ensure form rows in modals stack nicely */
-    .form-row, #contact-us-modal .form-row, #join-us-modal #join-form > .form-row:first-child {
-        grid-template-columns: 1fr; /* Stack all columns in modals */
+    /* General .form-row stacking */
+    .form-row, #contact-us-modal .form-row {
+        grid-template-columns: 1fr;
         gap: 0.8rem;
     }
-     #join-us-modal .lang-toggle {
-        top: 0.8rem;
-        right: 3rem;
-        font-size: 0.75rem;
+
+    /* Specifically for Join Us modal's new two-column structure */
+    #join-us-modal .form-columns {
+        flex-direction: column; /* Stack the columns */
+        gap: 1rem; /* Adjust gap for stacked columns */
     }
+    /* The .form-column > .form-row will naturally stack its items due to flex-direction: column */
+    /* No need to override #join-us-modal #join-form > .form-row:first-child specifically anymore */
+
+    /* Removed .lang-toggle style as it's gone */
+    /* #join-us-modal .lang-toggle { ... } */
 
     footer {
         padding-bottom: 70px; /* Space for mobile nav if footer becomes visible with scrolling */

--- a/index.html
+++ b/index.html
@@ -85,71 +85,76 @@
     <!-- Join Us Modal (using provided structure) -->
     <div id="join-us-modal" class="modal-overlay" style="display: none;">
         <div class="modal-content">
-            <div class="lang-toggle" id="join-us-lang-toggle" data-en="EN | ES" data-es="ES | EN">EN | ES</div>
             <div class="modal-header">
                 <h3 data-en="Join Us" data-es="Únete a Nosotros">Join Us</h3>
                 <button class="close-modal" data-close-modal="join-us-modal" aria-label="Close">&times;</button>
             </div>
             <form id="join-form">
-                <div class="form-row">
-                    <label for="name" data-en="Name" data-es="Nombre">Name</label>
-                    <input type="text" id="name" name="name" data-placeholder-en="Enter your name" data-placeholder-es="Ingresa tu nombre" />
+                <div class="form-columns"> <!-- New container for two columns -->
+                    <div class="form-column"> <!-- Left Column -->
+                        <div class="form-row"> <!-- Name, Email, Phone -->
+                            <label for="name" data-en="Name" data-es="Nombre">Name</label>
+                            <input type="text" id="name" name="name" data-placeholder-en="Enter your name" data-placeholder-es="Ingresa tu nombre" />
 
-                    <label for="email" data-en="Email" data-es="Correo Electrónico">Email</label>
-                    <input type="email" id="email" name="email" data-placeholder-en="Enter your email" data-placeholder-es="Ingresa tu correo" />
+                            <label for="email" data-en="Email" data-es="Correo Electrónico">Email</label>
+                            <input type="email" id="email" name="email" data-placeholder-en="Enter your email" data-placeholder-es="Ingresa tu correo" />
 
-                    <label for="phone" data-en="Phone" data-es="Teléfono">Phone</label>
-                    <input type="tel" id="phone" name="phone" data-placeholder-en="Enter your phone" data-placeholder-es="Ingresa tu teléfono" />
-                </div>
-                <div class="form-section" data-section="Skills">
-                    <div class="section-header">
-                        <h2 data-en="Skills" data-es="Habilidades">Skills</h2>
-                        <div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div>
+                            <label for="phone" data-en="Phone" data-es="Teléfono">Phone</label>
+                            <input type="tel" id="phone" name="phone" data-placeholder-en="Enter your phone" data-placeholder-es="Ingresa tu teléfono" />
+                        </div>
+                        <div class="form-section" data-section="Skills">
+                            <div class="section-header">
+                                <h2 data-en="Skills" data-es="Habilidades">Skills</h2>
+                                <div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div>
+                            </div>
+                            <div class="inputs"></div>
+                            <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+                            <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
+                        </div>
+                        <div class="form-section" data-section="Education">
+                            <div class="section-header">
+                                <h2 data-en="Education" data-es="Educación">Education</h2>
+                                <div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div>
+                            </div>
+                            <div class="inputs"></div>
+                            <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+                            <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
+                        </div>
                     </div>
-                    <div class="inputs"></div>
-                    <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
-                    <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
-                </div>
-                <div class="form-section" data-section="Education">
-                    <div class="section-header">
-                        <h2 data-en="Education" data-es="Educación">Education</h2>
-                        <div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div>
+                    <div class="form-column"> <!-- Right Column -->
+                        <div class="form-section" data-section="Continued Education">
+                          <div class="section-header">
+                              <h2 data-en="Continued Education" data-es="Educación Continua">Continued Education</h2>
+                              <div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div>
+                          </div>
+                          <div class="inputs"></div>
+                          <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+                          <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
+                        </div>
+                        <div class="form-section" data-section="Certification">
+                          <div class="section-header">
+                              <h2 data-en="Certification" data-es="Certificación">Certification</h2>
+                              <div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div>
+                          </div>
+                          <div class="inputs"></div>
+                          <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+                          <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
+                        </div>
+                        <div class="form-section" data-section="Hobbies">
+                          <div class="section-header">
+                              <h2 data-en="Hobbies" data-es="Pasatiempos">Hobbies</h2>
+                              <div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div>
+                          </div>
+                          <div class="inputs"></div>
+                          <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+                          <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
+                        </div>
+                        <div class="form-row"> <!-- Re-using form-row for the textarea to maintain similar styling if any -->
+                            <label for="comment" data-en="Tell us about yourself" data-es="Cuéntanos sobre ti">Tell us about yourself</label>
+                            <textarea id="comment" name="comment" rows="4" data-placeholder-en="Tell us about yourself..." data-placeholder-es="Cuéntanos sobre ti..."></textarea>
+                        </div>
                     </div>
-                    <div class="inputs"></div>
-                    <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
-                    <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
-                </div>
-                <div class="form-section" data-section="Continued Education">
-                  <div class="section-header">
-                      <h2 data-en="Continued Education" data-es="Educación Continua">Continued Education</h2>
-                      <div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div>
-                  </div>
-                  <div class="inputs"></div>
-                  <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
-                  <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
-                </div>
-                <div class="form-section" data-section="Certification">
-                  <div class="section-header">
-                      <h2 data-en="Certification" data-es="Certificación">Certification</h2>
-                      <div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div>
-                  </div>
-                  <div class="inputs"></div>
-                  <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
-                  <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
-                </div>
-                <div class="form-section" data-section="Hobbies">
-                  <div class="section-header">
-                      <h2 data-en="Hobbies" data-es="Pasatiempos">Hobbies</h2>
-                      <div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div>
-                  </div>
-                  <div class="inputs"></div>
-                  <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
-                  <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
-                </div>
-                <div class="form-row">
-                    <label for="comment" data-en="Tell us about yourself" data-es="Cuéntanos sobre ti">Tell us about yourself</label>
-                    <textarea id="comment" name="comment" rows="4" data-placeholder-en="Tell us about yourself..." data-placeholder-es="Cuéntanos sobre ti..."></textarea>
-                </div>
+                </div> <!-- End of form-columns -->
                 <div class="form-footer">
                     <button type="submit" class="submit-button" data-en="Submit" data-es="Enviar">Submit</button>
                 </div>

--- a/js/language-switcher.js
+++ b/js/language-switcher.js
@@ -2,7 +2,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     const desktopLangToggle = document.getElementById('language-toggle-button');
     const mobileLangToggle = document.getElementById('mobile-language-toggle');
-    const joinUsLangToggle = document.getElementById('join-us-lang-toggle');
 
     let currentLanguage = localStorage.getItem('language') || 'en';
 
@@ -61,11 +60,9 @@ document.addEventListener('DOMContentLoaded', () => {
         // Update toggle button texts
         const langToggleText = language === 'en' ? 'EN/ES' : 'ES/EN';
         const mobileLangToggleText = language === 'en' ? 'EN' : 'ES'; // Mobile shows current lang
-        const joinUsModalToggleText = language === 'en' ? 'EN | ES' : 'ES | EN';
 
         if (desktopLangToggle) desktopLangToggle.textContent = langToggleText;
         if (mobileLangToggle) mobileLangToggle.textContent = mobileLangToggleText;
-        if (joinUsLangToggle) joinUsLangToggle.textContent = joinUsModalToggleText;
 
 
         // Special handling for Join Us modal input placeholders (dynamic)
@@ -98,9 +95,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (mobileLangToggle) {
         mobileLangToggle.addEventListener('click', toggleLanguage);
-    }
-    if (joinUsLangToggle) { // This one is specific to the Join Us modal
-        joinUsLangToggle.addEventListener('click', toggleLanguage);
     }
 
     // Expose for other scripts if needed (e.g., dynamic content)


### PR DESCRIPTION
- Divides the 'Únete a Nosotros' form fields into two horizontally and vertically aligned columns for improved readability on larger screens.
- Removes the redundant language (EN/ES) toggle button from within the Join Us modal, relying on the main site language switcher.
- Ensures the form columns stack vertically on smaller screens for responsiveness.