### PR TITLE
Fix: Hide mobile navigation elements on landing page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -434,6 +434,13 @@ textarea {
 
 
 /* ===== Mobile Navigation Styling ===== */
+/* Hide on landing page */
+.landing-page .mobile-nav,
+.landing-page .mobile-services-menu,
+.landing-page #mobile-menu-toggle {
+    display: none !important;
+}
+
 .mobile-nav {
     display: none; /* Hidden by default, shown via media query */
     position: fixed;

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <!-- Font Awesome CDN -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
-<body>
+<body class="landing-page">
     <!-- Skip to main content for accessibility -->
     <a href="#services" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to main content</a>
 


### PR DESCRIPTION
- Added 'landing-page' class to index.html body.
- Added CSS to hide mobile-nav, mobile-services-menu, and mobile-menu-toggle on .landing-page.
- This ensures these elements are not displayed on the main landing page but will still be available for other pages on adaptable screens as per existing styles.