### PR TITLE
feat: Implement website text, theme, and localization updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     <header class="site-header">
         <div class="header-content">
             <h1 class="main-header-text" data-en="OPS" data-es="OPS">OPS</h1>
-            <p class="sub-header-text" data-en="OPS Online Support&trade;" data-es="Soporte en Línea OPS&trade;">OPS Online Support&trade;</p>
+            <p class="sub-header-text" data-en="OPS Online Support&trade;" data-es="OPS Online Support&trade;">OPS Online Support&trade;</p>
         </div>
         <div class="header-toggles">
             <!-- Theme Toggle will be a styled button/switch -->
@@ -147,7 +147,7 @@
                   <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display: none;">Edit</button>
                 </div>
                 <div class="form-row">
-                    <label for="comment" data-en="Tell us about yourself" data-es="Cuéntanos sobre ti">Tell us about yourself</label>
+                    <label for="comment" data-en="Tell Us about Yourself" data-es="Cuéntanos sobre ti">Tell Us about Yourself</label>
                     <textarea id="comment" name="comment" rows="4" data-placeholder-en="Tell us about yourself..." data-placeholder-es="Cuéntanos sobre ti..."></textarea>
                 </div>
                 <div class="form-footer">
@@ -178,7 +178,7 @@
                     </div>
                     <div class="form-row">
                         <div class="form-cell">
-                            <label for="contact-number" data-en="Contact Number" data-es="Número de Contacto">Contact Number</label>
+                             <label for="contact-number" data-en="Contact Number" data-es="Teléfono">Contact Number</label>
                             <input type="tel" id="contact-number" data-placeholder-en="Enter your contact number" data-placeholder-es="Ingrese su número" required>
                         </div>
                         <div class="form-cell">
@@ -264,7 +264,7 @@
 
     <!-- Footer -->
     <footer>
-        <p data-en="&copy; 2023 OPS Online Support" data-es="&copy; 2023 Soporte en Línea OPS">&copy; 2023 OPS Online Support</p>
+        <p data-en="&copy; 2025 OPS Online Support" data-es="&copy; 2025 OPS Online Support">&copy; 2025 OPS Online Support</p>
     </footer>
 
     <!-- Mobile Bottom Navigation & Services Menu (Small Screens) -->

--- a/js/theme-switcher.js
+++ b/js/theme-switcher.js
@@ -18,30 +18,28 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function updateButtonTexts(theme) {
         const lang = (window.getCurrentLanguage && window.getCurrentLanguage()) || 'en';
-        let desktopText, mobileText, ariaLabel;
+        let desktopBaseText, mobileCurrentThemeText, ariaLabel;
+
+        // Desktop button base text
+        desktopBaseText = lang === 'es' ? 'Tema' : 'Theme';
 
         if (theme === 'light') {
-            desktopText = lang === 'es' ? 'Tema: Claro' : 'Theme: Light';
-            mobileText = lang === 'es' ? 'Claro' : 'Light';
+            mobileCurrentThemeText = lang === 'es' ? 'Claro' : 'Light';
             ariaLabel = lang === 'es' ? 'Cambiar a tema oscuro' : 'Switch to dark theme';
         } else { // dark theme
-            desktopText = lang === 'es' ? 'Tema: Oscuro' : 'Theme: Dark';
-            mobileText = lang === 'es' ? 'Oscuro' : 'Dark';
+            mobileCurrentThemeText = lang === 'es' ? 'Oscuro' : 'Dark';
             ariaLabel = lang === 'es' ? 'Cambiar a tema claro' : 'Switch to light theme';
         }
 
         if (desktopThemeToggle) {
-            desktopThemeToggle.textContent = desktopText;
+            desktopThemeToggle.textContent = desktopBaseText; // Only "Theme" or "Tema"
             desktopThemeToggle.setAttribute('aria-label', ariaLabel);
             desktopThemeToggle.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
         }
         if (mobileThemeToggle) {
-            // Mobile toggle usually shows the current state or the action to switch
-            // For simplicity, let's make it show the current state similar to language.
-            mobileThemeToggle.textContent = mobileText; // e.g., "Light" or "Dark"
-            mobileThemeToggle.setAttribute('aria-label', ariaLabel);
+            mobileThemeToggle.textContent = mobileCurrentThemeText; // e.g., "Light" or "Dark"
+            mobileThemeToggle.setAttribute('aria-label', ariaLabel); // Same aria-label as desktop for action
             mobileThemeToggle.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
-
         }
     }
 


### PR DESCRIPTION
This commit addresses several UI and localization requests:

- Updated copyright year to 2025 and text to "© 2025 OPS Online Support" for both EN and ES.
- Changed header sub-text to "OPS Online Support™" for both EN and ES.
- Modified theme switcher:
    - Desktop button now displays "Theme" (or "Tema") only.
    - Mobile button displays current theme state ("Light"/"Dark").
    - Aria-labels are updated dynamically.
- Verified language switcher functionality for button text (desktop: "EN/ES" or "ES/EN"; mobile: current language).
- Confirmed service modals use near-black font color in light theme.
- Updated form field labels in Join Us and Contact Us modals for EN and ES versions (e.g., "Tell Us about Yourself", "Teléfono").
- Verified mobile navigation visibility based on screen size.