### PR TITLE
Refactor: Update theme toggle button to display Dark/Light

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
         </div>
         <div class="header-toggles">
             <!-- Theme Toggle will be a styled button/switch -->
-            <button id="theme-toggle-button" class="header-toggle-btn" aria-label="Toggle theme" data-en="Theme" data-es="Tema">Theme</button>
+            <button id="theme-toggle-button" class="header-toggle-btn" aria-label="Toggle theme">Dark</button>
             <!-- Language Toggle will be a styled button/switch -->
             <button id="language-toggle-button" class="header-toggle-btn" aria-label="Toggle language" data-en="EN/ES" data-es="ES/EN">EN/ES</button>
         </div>

--- a/js/theme-switcher.js
+++ b/js/theme-switcher.js
@@ -18,26 +18,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function updateButtonTexts(theme) {
         const lang = (window.getCurrentLanguage && window.getCurrentLanguage()) || 'en';
-        let desktopBaseText, mobileCurrentThemeText, ariaLabel;
-
-        // Desktop button base text
-        desktopBaseText = lang === 'es' ? 'Tema' : 'Theme';
+        let currentThemeText, ariaLabel;
 
         if (theme === 'light') {
-            mobileCurrentThemeText = lang === 'es' ? 'Claro' : 'Light';
+            currentThemeText = lang === 'es' ? 'Claro' : 'Light';
             ariaLabel = lang === 'es' ? 'Cambiar a tema oscuro' : 'Switch to dark theme';
         } else { // dark theme
-            mobileCurrentThemeText = lang === 'es' ? 'Oscuro' : 'Dark';
+            currentThemeText = lang === 'es' ? 'Oscuro' : 'Dark';
             ariaLabel = lang === 'es' ? 'Cambiar a tema claro' : 'Switch to light theme';
         }
 
         if (desktopThemeToggle) {
-            desktopThemeToggle.textContent = desktopBaseText; // Only "Theme" or "Tema"
+            desktopThemeToggle.textContent = currentThemeText; // Display current theme (e.g., "Dark" or "Light")
             desktopThemeToggle.setAttribute('aria-label', ariaLabel);
             desktopThemeToggle.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
         }
         if (mobileThemeToggle) {
-            mobileThemeToggle.textContent = mobileCurrentThemeText; // e.g., "Light" or "Dark"
+            mobileThemeToggle.textContent = currentThemeText; // e.g., "Light" or "Dark"
             mobileThemeToggle.setAttribute('aria-label', ariaLabel); // Same aria-label as desktop for action
             mobileThemeToggle.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
         }


### PR DESCRIPTION
- Modified index.html to set initial text of the desktop theme toggle button to 'Dark' and removed static language data attributes.
- Updated js/theme-switcher.js to dynamically change the desktop theme toggle button's text to 'Dark'/'Light' (and Spanish equivalents 'Oscuro'/'Claro') to reflect the current theme state.
- This makes the desktop button's text behavior consistent with the mobile theme toggle button.