### PR TITLE
Add extensive debugging for modal visibility and focus issues

### DIFF
--- a/js/language-switcher.js
+++ b/js/language-switcher.js
@@ -115,6 +115,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const joinUsModal = document.getElementById('join-us-modal');
         if (joinUsModal) {
             joinUsModal.querySelectorAll('.form-section').forEach(section => {
+                // Ensure section is a valid element before proceeding
+                if (!section || typeof section.querySelector !== 'function' || typeof section.querySelectorAll !== 'function' || !section.dataset) {
+                    console.warn('[language-switcher] Invalid section element encountered in join-us-modal processing:', section);
+                    return; // Skip this iteration
+                }
+
                 const sectionTitleElement = section.querySelector('h2');
                 let sectionNameForPlaceholder = section.dataset.section; // Default to data-section value
 


### PR DESCRIPTION
- Make language-switcher.js more robust against errors during placeholder updates.
- Add detailed logging to getFocusableElements to inspect candidate properties (offsetParent, computed styles).
- Change deferred focus logic in openModalHandler to use setTimeout(0) instead of requestAnimationFrame.
- Add logging of computed display styles in openModalHandler immediately after JS attempts to set them.

These changes are intended to help diagnose why modals might not be appearing or why focusable elements are not being detected.