### PR TITLE
Refactor: Improve contact form validation and UX

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -480,6 +480,34 @@ textarea {
     opacity: 1; /* Firefox Fix */
 }
 
+/* Styling for invalid form fields */
+.form-field-invalid, input.form-field-invalid, textarea.form-field-invalid, select.form-field-invalid {
+    border-color: var(--danger-color, red) !important; /* Use a theme variable if available, else fallback to red */
+    /* Consider adding a subtle box-shadow or background change for more emphasis if desired */
+    /* e.g., box-shadow: 0 0 0 2px rgba(255, 0, 0, 0.2); */
+}
+/* Ensure focus styles on invalid fields still work or are distinct */
+.form-field-invalid:focus, input.form-field-invalid:focus, textarea.form-field-invalid:focus, select.form-field-invalid:focus {
+    border-color: var(--danger-color, red) !important; /* Keep border red */
+    box-shadow: 0 0 0 2px var(--danger-color-faded, rgba(255, 0, 0, 0.3)) !important; /* Adjust shadow to indicate focus on invalid field */
+}
+/* Styling for the error message container */
+.form-error-message {
+    color: var(--danger-color, red);
+    background-color: var(--danger-bg-color, #fdd); /* Light red background */
+    border: 1px solid var(--danger-border-color, var(--danger-color, red));
+    padding: 0.75rem 1rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1rem;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    display: none; /* Hidden by default */
+}
+.form-error-message.visible {
+    display: block; /* Shown by JS */
+}
+
+
 /* Ensure buttons within modals are contained */
 .modal-content .form-section { /* form-footer removed from here to allow its own styling */
     overflow: hidden; /* Prevents internal button hover effects from spilling */

--- a/index.html
+++ b/index.html
@@ -199,6 +199,9 @@
           <button class="close-modal" data-close-modal="contact-us-modal" aria-label="Close">&times;</button>
         </div>
 
+        <!-- Form Error Message Area -->
+        <div id="contact-form-error-message" class="form-error-message" role="alert" aria-live="assertive"></div>
+
         <!-- Modal Body -->
         <div class="modal-body">
           <form id="contact-form">

--- a/js/contact-form-handler.js
+++ b/js/contact-form-handler.js
@@ -2,37 +2,55 @@
 document.addEventListener('DOMContentLoaded', () => {
     const contactForm = document.getElementById('contact-form');
     const contactModal = document.getElementById('contact-us-modal');
+    const errorMessageContainer = document.getElementById('contact-form-error-message');
 
-    if (contactForm && contactModal) {
+    if (contactForm && contactModal && errorMessageContainer) {
         contactForm.addEventListener('submit', (event) => {
             event.preventDefault(); // Prevent default form submission
 
+            // Clear previous error messages
+            errorMessageContainer.textContent = '';
+            errorMessageContainer.classList.remove('visible');
+
             // Basic validation: Check if all required fields are filled
             let isValid = true;
+            let firstInvalidField = null;
             const requiredFields = contactForm.querySelectorAll('[required]');
+
             requiredFields.forEach(field => {
                 if (!field.value.trim()) {
                     isValid = false;
-                    // Optionally, add some visual feedback for empty required fields
-                    field.style.borderColor = 'red';
+                    field.classList.add('form-field-invalid');
+                    field.setAttribute('aria-invalid', 'true');
+                    if (!firstInvalidField) {
+                        firstInvalidField = field;
+                    }
                 } else {
-                    field.style.borderColor = ''; // Reset border color
+                    field.classList.remove('form-field-invalid');
+                    field.removeAttribute('aria-invalid');
                 }
             });
 
             if (!isValid) {
                 const currentLang = (window.getCurrentLanguage && window.getCurrentLanguage()) || 'en';
-                alert(currentLang === 'es' ? 'Por favor, complete todos los campos requeridos.' : 'Please fill in all required fields.');
+                errorMessageContainer.textContent = currentLang === 'es' ? 'Por favor, complete todos los campos requeridos.' : 'Please fill in all required fields.';
+                errorMessageContainer.classList.add('visible');
+                if (firstInvalidField) {
+                    firstInvalidField.focus();
+                }
                 return;
             }
 
             // Simulate form submission
-            const currentLang = (window.getCurrentLanguage && window.getCurrentLanguage()) || 'en';
-            alert(currentLang === 'es' ? 'Gracias por contactarnos. Su mensaje ha sido enviado (simulado).' : 'Thank you for contacting us. Your message has been sent (simulated).');
+            // const currentLang = (window.getCurrentLanguage && window.getCurrentLanguage()) || 'en'; // No longer needed for alert
+            // alert(currentLang === 'es' ? 'Gracias por contactarnos. Su mensaje ha sido enviado (simulado).' : 'Thank you for contacting us. Your message has been sent (simulated).'); // Removed success alert
 
             // Reset form fields
             contactForm.reset();
-            requiredFields.forEach(field => field.style.borderColor = ''); // Reset borders
+            requiredFields.forEach(field => {
+                field.classList.remove('form-field-invalid');
+                field.removeAttribute('aria-invalid');
+            });
 
             // Close the modal
             // Assumes a global closeModal function is available (e.g., from dynamic-modal-manager.js)
@@ -50,16 +68,21 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
 
-        // Optional: Reset border colors when user starts typing in a field
+        // Optional: Reset border colors and aria-invalid when user starts typing in a field
         contactForm.querySelectorAll('[required]').forEach(field => {
             field.addEventListener('input', () => {
-                if (field.style.borderColor === 'red') {
-                    field.style.borderColor = '';
+                // If field has content, remove invalid class and aria-attribute
+                if (field.value.trim()) {
+                    field.classList.remove('form-field-invalid');
+                    field.removeAttribute('aria-invalid');
                 }
+                // No need for an 'else' here, as the submit validation will catch empty/invalid fields.
+                // This listener primarily serves to remove the error state as the user types.
             });
         });
     } else {
         if (!contactForm) console.warn('Contact form (#contact-form) not found.');
         if (!contactModal) console.warn('Contact modal (#contact-us-modal) not found.');
+        if (!errorMessageContainer) console.warn('Error message container (#contact-form-error-message) not found.');
     }
 });


### PR DESCRIPTION
- Replaced inline styling for invalid fields with CSS classes (.form-field-invalid).
- Displayed validation errors in a dedicated element within the modal instead of using alerts.
- Removed success alert; successful submission is implied by form reset and modal closure.
- Added basic accessibility:
  - Focused the first invalid field on validation error.
  - Set/removed `aria-invalid` attributes on fields.
  - Ensured error message container has `role="alert"`.
- Added relevant CSS for new states and error messages.