### PR TITLE
Feat: Position copyright footer at bottom center of viewport

### DIFF
--- a/css/main_style.css
+++ b/css/main_style.css
@@ -65,6 +65,7 @@ main {
     padding: 1rem 2rem;
     max-width: 1200px;
     margin: 0 auto;
+    padding-bottom: 3rem; /* Ensure space for the fixed footer */
 }
 
 /* Services Section & Navigation */
@@ -803,4 +804,23 @@ main {
     /* Restore display of old mobile nav if it was different for desktop (unlikely) */
      .mobile-nav#mobile-bottom-nav { display: none; } /* Keep old nav hidden on desktop too */
      .mobile-services-menu#mobile-services-panel { display: none; }
+}
+
+/* ===== Footer Styling ===== */
+footer {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--header-bg-color); /* Using header background as a sensible default */
+    color: var(--text-color-main); /* Ensure text color matches theme */
+    padding: 0.5rem;
+    text-align: center;
+    z-index: 998; /* Below FABs (1020) and Modals (1040/1050) but above general content */
+    border-top: 1px solid var(--header-border-color); /* Consistent with header */
+}
+
+footer p {
+    margin: 0; /* Remove default paragraph margin */
+    font-size: 0.85rem; /* Slightly smaller text for footer */
 }

--- a/css/small-screen.css
+++ b/css/small-screen.css
@@ -10,7 +10,7 @@
     /* Example: Adjust main content padding for smaller screens */
     main {
         padding: 1rem; /* Less horizontal padding on smaller screens */
-        /* Padding bottom might be adjusted by specific mobile navs if they are fixed */
+        padding-bottom: 7rem; /* Adjusted to clear mobile navs (which are on top of the new footer) */
     }
 
     .site-header {
@@ -82,11 +82,6 @@
         grid-template-columns: 1fr;
         gap: 0.8rem;
     } */
-
-    footer {
-         /* Add padding-bottom if mobile navigation is fixed and might overlap */
-         /* padding-bottom: 70px; */
-    }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
- Modified CSS to make the footer fixed at the bottom center.
- Adjusted main content padding to prevent overlap with the footer and existing mobile navigation elements.
- Ensured footer adapts to theme changes and interacts correctly with other fixed/sticky elements based on z-index.