### PR TITLE
Fix: Ensure service modals are viewable on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,10 +165,10 @@
     </nav>
     <div class="mobile-services-menu" id="mobile-services-panel">
         <ul>
-            <li><button data-service-target="business-operations-modal" data-modal-source="components/service-modals/business-operations.html" data-en="Business Operations" data-es="Gestion">Business Operations</button></li>
-            <li><button data-service-target="contact-center-modal" data-modal-source="components/service-modals/contact-center.html" data-en="Contact Center" data-es="Centro de Servicios">Contact Center</button></li>
-            <li><button data-service-target="it-support-modal" data-modal-source="components/service-modals/it-support.html" data-en="IT Support" data-es="Soporte Tecnico">IT Support</button></li>
-            <li><button data-service-target="professionals-modal" data-modal-source="components/service-modals/professionals.html" data-en="Professionals" data-es="Profesionales">Professionals</button></li>
+            <li><button data-modal-target="business-operations-modal" data-modal-source="components/service-modals/business-operations.html" data-en="Business Operations" data-es="Gestion">Business Operations</button></li>
+            <li><button data-modal-target="contact-center-modal" data-modal-source="components/service-modals/contact-center.html" data-en="Contact Center" data-es="Centro de Servicios">Contact Center</button></li>
+            <li><button data-modal-target="it-support-modal" data-modal-source="components/service-modals/it-support.html" data-en="IT Support" data-es="Soporte Tecnico">IT Support</button></li>
+            <li><button data-modal-target="professionals-modal" data-modal-source="components/service-modals/professionals.html" data-en="Professionals" data-es="Profesionales">Professionals</button></li>
         </ul>
     </div>
 
@@ -182,10 +182,10 @@
     </nav>
     <div class="mobile-services-menu" id="newMobileServicesMenu" aria-hidden="true">
         <ul>
-            <li><button data-service-target="business-operations-modal" data-modal-source="components/service-modals/business-operations.html" data-en="Business Operations" data-es="Operaciones Empresariales">Business Operations</button></li>
-            <li><button data-service-target="contact-center-modal" data-modal-source="components/service-modals/contact-center.html" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</button></li>
-            <li><button data-service-target="it-support-modal" data-modal-source="components/service-modals/it-support.html" data-en="IT Support" data-es="Soporte IT">IT Support</button></li>
-            <li><button data-service-target="professionals-modal" data-modal-source="components/service-modals/professionals.html" data-en="Professionals" data-es="Profesionales">Professionals</button></li>
+            <li><button data-modal-target="business-operations-modal" data-modal-source="components/service-modals/business-operations.html" data-en="Business Operations" data-es="Operaciones Empresariales">Business Operations</button></li>
+            <li><button data-modal-target="contact-center-modal" data-modal-source="components/service-modals/contact-center.html" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</button></li>
+            <li><button data-modal-target="it-support-modal" data-modal-source="components/service-modals/it-support.html" data-en="IT Support" data-es="Soporte IT">IT Support</button></li>
+            <li><button data-modal-target="professionals-modal" data-modal-source="components/service-modals/professionals.html" data-en="Professionals" data-es="Profesionales">Professionals</button></li>
         </ul>
     </div>
 

--- a/js/dynamic-modal-manager.js
+++ b/js/dynamic-modal-manager.js
@@ -7,8 +7,8 @@ document.addEventListener('DOMContentLoaded', () => {
     window.openModalById = function(modalId) {
         const modal = document.getElementById(modalId);
         if (modal) {
-            if (modalBackdrop) modalBackdrop.style.display = 'block';
-            modal.style.display = 'flex';
+            if (modalBackdrop) modalBackdrop.style.setProperty('display', 'block', 'important');
+            modal.style.setProperty('display', 'flex', 'important');
             if (window.applyTranslations && window.getCurrentLanguage) {
                 setTimeout(() => window.applyTranslations(window.getCurrentLanguage()), 0);
             }
@@ -56,8 +56,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const htmlText = await response.text();
             (modalBody || modal.querySelector('.modal-content')).innerHTML = htmlText; // Use modal-body, fallback to modal-content
 
-            if (modalBackdrop) modalBackdrop.style.display = 'block';
-            modal.style.display = 'flex';
+            if (modalBackdrop) modalBackdrop.style.setProperty('display', 'block', 'important');
+            modal.style.setProperty('display', 'flex', 'important');
 
             if (window.applyTranslations && window.getCurrentLanguage) {
                  setTimeout(() => {
@@ -87,16 +87,16 @@ document.addEventListener('DOMContentLoaded', () => {
                     window.applyTranslations(window.getCurrentLanguage());
                 }
             }
-            if (modalBackdrop) modalBackdrop.style.display = 'block'; // Still show modal, but with error
-            modal.style.display = 'flex';
+            if (modalBackdrop) modalBackdrop.style.setProperty('display', 'block', 'important'); // Still show modal, but with error
+            modal.style.setProperty('display', 'flex', 'important');
         }
     };
 
     window.closeModal = function(modalOrId) {
         const modal = typeof modalOrId === 'string' ? document.getElementById(modalOrId) : modalOrId;
-        if (modal && modal.style.display !== 'none') {
-            modal.style.display = 'none';
-            if (modalBackdrop) modalBackdrop.style.display = 'none';
+        if (modal && (modal.style.display === 'flex' || modal.style.display === 'block')) { // Check against flex or block
+            modal.style.setProperty('display', 'none', 'important'); // Also use important for closing
+            if (modalBackdrop) modalBackdrop.style.setProperty('display', 'none', 'important'); // Also use important for closing
 
             const modalBody = modal.querySelector('.modal-body');
             const modalContent = modal.querySelector('.modal-content'); // Fallback


### PR DESCRIPTION
- Modified js/dynamic-modal-manager.js to use `setProperty('display', '...', 'important')` when showing/hiding modals and backdrops. This is to ensure JavaScript's display instructions override potentially conflicting CSS if modals were not appearing.
- Previously changed data-service-target to data-modal-target in index.html for mobile menu buttons.