### PR TITLE
Style: Position service modals 450px from top

### DIFF
--- a/css/main_style.css
+++ b/css/main_style.css
@@ -272,6 +272,14 @@ main {
 .service-modal-center .modal-content {
     max-width: 600px;
     text-align: center;
+    position: fixed; /* Position relative to the viewport */
+    top: 450px; /* Specific offset from the top */
+    left: 50%;
+    transform: translateX(-50%); /* Center horizontally */
+    /* Override any potential inherited display that might interfere */
+    display: block; /* Or flex, if inner content requires it, but block is fine for a container */
+    /* The width: 100% from .modal-content might make it too wide if not constrained by max-width.
+       Relying on max-width: 600px. Ensure width is not an issue. */
 }
 .service-modal-center .modal-body {
     font-size: 1.1rem;


### PR DESCRIPTION
Updated CSS for service modals (Gestion, Centro de Servicios, Soporte Tecnico, Profesionales) to be positioned 450px from the top of the viewport and horizontally centered.

- Modified `css/main_style.css` for `.service-modal-center .modal-content`.
- Set `top: 450px` and `transform: translateX(-50%)`.
- This revises the previous centering logic to a specific offset as requested.