### PR TITLE
feat: Enhance modal and FAB closing behaviors

### DIFF
--- a/components/chatbot/chatbot-widget.js
+++ b/components/chatbot/chatbot-widget.js
@@ -26,6 +26,9 @@ document.addEventListener('DOMContentLoaded', () => {
             addMessageToLog(userMessage, 'user-message');
             chatInput.value = ''; // Clear input
 
+            // Post message to parent to close the modal
+            window.parent.postMessage('closeChatbotModal', '*');
+
             // Simulate bot response
             setTimeout(() => {
                 simulateBotResponse(userMessage);

--- a/js/dynamic-modal-manager.js
+++ b/js/dynamic-modal-manager.js
@@ -154,4 +154,17 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     });
+
+    // Add listener for messages from iframes (e.g., chatbot)
+    window.addEventListener('message', (event) => {
+        // Consider checking event.origin for security if the source is known e.g.
+        // if (event.origin !== window.location.origin) return;
+        if (event.data === 'closeChatbotModal') {
+            const chatbotModal = document.getElementById('chatbot-modal');
+            // Check if the modal exists and is currently displayed
+            if (chatbotModal && (chatbotModal.style.display === 'flex' || chatbotModal.style.display === 'block')) {
+                window.closeModal(chatbotModal);
+            }
+        }
+    });
 });

--- a/js/mobile-fab-nav.js
+++ b/js/mobile-fab-nav.js
@@ -100,4 +100,48 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     });
+
+    // Add ESC key listener for closing mobile FAB nav and its sub-menu
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+            const isMobileNavActive = mobileNav && mobileNav.classList.contains('active');
+            const isServicesMenuActive = servicesMenu && servicesMenu.classList.contains('active');
+
+            if (isMobileNavActive || isServicesMenuActive) {
+                // Check if a modal is open. If so, let the modal's ESC handler take precedence.
+                const anyModalOpen = Array.from(document.querySelectorAll('.modal-overlay')).some(
+                    modal => modal.style.display === 'flex' || modal.style.display === 'block'
+                );
+
+                if (!anyModalOpen) {
+                    if (isServicesMenuActive) {
+                        servicesMenu.classList.remove('active');
+                        servicesMenu.setAttribute('aria-hidden', 'true');
+                        if (servicesToggle) servicesToggle.setAttribute('aria-expanded', 'false');
+                        // Typically, closing a submenu should not automatically close its parent menu
+                        // unless that's the desired UX. Here, we allow the main nav to remain.
+                        // If the main nav should also close, additional logic is needed.
+                        // For now, ESC will close the topmost active FAB menu element.
+                    } else if (isMobileNavActive) { // Only close main nav if service menu wasn't the target
+                        mobileNav.classList.remove('active');
+                        if (fabToggle) {
+                            fabToggle.setAttribute('aria-expanded', 'false');
+                            const icon = fabToggle.querySelector('i');
+                            if (icon) {
+                                icon.classList.remove('fa-times');
+                                icon.classList.add('fa-bars');
+                            }
+                        }
+                        // If services menu was open INSIDE mobileNav, it's already handled by the click-outside logic
+                        // or if we want explicit close:
+                        // if (servicesMenu && servicesMenu.classList.contains('active')) {
+                        //     servicesMenu.classList.remove('active');
+                        //     servicesMenu.setAttribute('aria-hidden', 'true');
+                        //     if(servicesToggle) servicesToggle.setAttribute('aria-expanded', 'false');
+                        // }
+                    }
+                }
+            }
+        }
+    });
 });


### PR DESCRIPTION
Implements the following closing behaviors:
- Chatbot modal now closes when a message is sent.
- Mobile navigation FAB menu (horizontal nav) now closes on 'ESC' key press, respecting active modal states.

Verifies and relies on existing functionality for:
- Standard modal closure (X, ESC, click outside) for all service modals, Join Us, Contact Us, and Chatbot modals.
- Closure of Join Us and Contact Us modals upon form submission ('Send').
- Mobile navigation FAB menu closure via its toggle button (acting as 'X') and click-outside.