### PR TITLE
fix: Update modal and FAB closing behaviors

### DIFF
--- a/components/chatbot/chatbot-widget.js
+++ b/components/chatbot/chatbot-widget.js
@@ -26,6 +26,10 @@ document.addEventListener('DOMContentLoaded', () => {
             addMessageToLog(userMessage, 'user-message');
             chatInput.value = ''; // Clear input
 
+            // Post message to parent to close the modal
+            // console.log('[ChatbotWidget] Form submitted. Attempting to post "closeChatbotModal" message to parent.'); // Cleanup
+            window.parent.postMessage('closeChatbotModal', '*');
+
             // Simulate bot response
             setTimeout(() => {
                 simulateBotResponse(userMessage);

--- a/components/service-modals/business-operations.html
+++ b/components/service-modals/business-operations.html
@@ -1,2 +1,5 @@
 <p data-en="Detailed content for Business Operations will go here. This section describes our comprehensive business operation solutions, tailored to streamline your processes and enhance efficiency." data-es="El contenido detallado para Operaciones de Negocio irá aquí. Esta sección describe nuestras soluciones integrales de operación comercial, diseñadas para optimizar sus procesos y mejorar la eficiencia.">Detailed content for Business Operations will go here. This section describes our comprehensive business operation solutions, tailored to streamline your processes and enhance efficiency.</p>
 <!-- Add more specific HTML structure as needed later -->
+<div class="modal-footer">
+    <button class="service-modal-send-button" data-en="Send" data-es="Enviar">Send</button>
+</div>

--- a/components/service-modals/contact-center.html
+++ b/components/service-modals/contact-center.html
@@ -1,2 +1,5 @@
 <p data-en="Detailed content for Contact Center services will go here. Discover how our advanced contact center solutions can improve customer engagement and support." data-es="El contenido detallado para los servicios de Contact Center irá aquí. Descubra cómo nuestras soluciones avanzadas de centro de contacto pueden mejorar la participación y el soporte al cliente.">Detailed content for Contact Center services will go here. Discover how our advanced contact center solutions can improve customer engagement and support.</p>
 <!-- Add more specific HTML structure as needed later -->
+<div class="modal-footer">
+    <button class="service-modal-send-button" data-en="Send" data-es="Enviar">Send</button>
+</div>

--- a/components/service-modals/it-support.html
+++ b/components/service-modals/it-support.html
@@ -1,2 +1,5 @@
 <p data-en="Detailed content for IT Support services will go here. We provide expert IT support to ensure your systems run smoothly and securely." data-es="El contenido detallado para los servicios de Soporte de TI irá aquí. Brindamos soporte de TI experto para garantizar que sus sistemas funcionen sin problemas y de forma segura.">Detailed content for IT Support services will go here. We provide expert IT support to ensure your systems run smoothly and securely.</p>
 <!-- Add more specific HTML structure as needed later -->
+<div class="modal-footer">
+    <button class="service-modal-send-button" data-en="Send" data-es="Enviar">Send</button>
+</div>

--- a/components/service-modals/professionals.html
+++ b/components/service-modals/professionals.html
@@ -1,2 +1,5 @@
 <p data-en="Detailed content for Professionals services will go here. Connect with our network of skilled professionals to meet your specialized project needs." data-es="El contenido detallado para los servicios de Profesionales irá aquí. Conéctese con nuestra red de profesionales calificados para satisfacer las necesidades especializadas de su proyecto.">Detailed content for Professionals services will go here. Connect with our network of skilled professionals to meet your specialized project needs.</p>
 <!-- Add more specific HTML structure as needed later -->
+<div class="modal-footer">
+    <button class="service-modal-send-button" data-en="Send" data-es="Enviar">Send</button>
+</div>

--- a/js/dynamic-modal-manager.js
+++ b/js/dynamic-modal-manager.js
@@ -2,6 +2,7 @@
 
 document.addEventListener('DOMContentLoaded', () => {
     const modalBackdrop = document.getElementById('modal-backdrop');
+    // console.log('[DMM] Modal Backdrop Element:', modalBackdrop); // Cleanup
 
     // Function to open a modal by its ID (for modals with static content)
     window.openModalById = function(modalId) {
@@ -130,18 +131,73 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    if (modalBackdrop) {
-        modalBackdrop.addEventListener('click', () => {
-            document.querySelectorAll('.modal-overlay').forEach(modal => {
-                if (modal.style.display === 'flex' || modal.style.display === 'block') {
-                    window.closeModal(modal);
-                }
-            });
-        });
-    }
+    // Direct modalBackdrop click listener is commented out as overlay click logic is preferred.
+    // if (modalBackdrop) {
+    //     modalBackdrop.addEventListener('click', () => {
+    //         document.querySelectorAll('.modal-overlay').forEach(modal => {
+    //             if (modal.style.display === 'flex' || modal.style.display === 'block') {
+    //                 window.closeModal(modal);
+    //             }
+    //         });
+    //     });
+    // }
+
+    document.addEventListener('click', (event) => {
+        const trigger = event.target.closest('[data-modal-target]');
+        if (trigger) {
+            event.preventDefault();
+            const modalId = trigger.dataset.modalTarget;
+            const modalSourceUrl = trigger.dataset.modalSource;
+            // console.log(`[DMM] Modal trigger clicked for target: ${modalId}, source: ${modalSourceUrl || 'none'}`); // Cleanup
+
+            if (modalSourceUrl) {
+                window.openModalWithContent(modalId, modalSourceUrl);
+            } else {
+                window.openModalById(modalId);
+            }
+        }
+
+        const closeButton = event.target.closest('[data-close-modal]');
+        if (closeButton) {
+            event.preventDefault();
+            const modalToClose = closeButton.closest('.modal-overlay') || document.getElementById(closeButton.dataset.closeModal);
+            if(modalToClose) {
+                // console.log(`[DMM] Close button clicked for modal: ${modalToClose.id}`); // Cleanup
+                window.closeModal(modalToClose);
+            } else {
+                // console.warn(`[DMM] Close button clicked, but no modal found for selector: ${closeButton.dataset.closeModal}`); // Cleanup
+            }
+        }
+
+        // New logic for clicking on overlay to close
+        const clickedOverlay = event.target.closest('.modal-overlay');
+        // Check if the event target is the overlay itself (i.e., not a child element like modal-content)
+        if (clickedOverlay && event.target === clickedOverlay) {
+            if (clickedOverlay.style.display === 'flex' || clickedOverlay.style.display === 'block') {
+                // console.log(`[DMM] Clicked directly on overlay ${clickedOverlay.id}. Closing.`); // Cleanup
+                window.closeModal(clickedOverlay);
+            }
+        }
+
+        const serviceSendButton = event.target.closest('.service-modal-send-button');
+        if (serviceSendButton) {
+            event.preventDefault(); // Prevent any default button action if it were, e.g., a submit type in a form
+            const modalToClose = serviceSendButton.closest('.modal-overlay');
+            if (modalToClose) {
+                // console.log(`[DMM] Service modal Send button clicked in modal: ${modalToClose.id}.`); // Cleanup
+                // Placeholder for actual data gathering and sending logic
+                // console.log('[DMM] Placeholder: Perform data gathering, security checks, and send to Cloudflare worker here.'); // Cleanup
+                window.closeModal(modalToClose);
+            } else {
+                // console.warn('[DMM] Service modal Send button clicked, but could not find parent modal to close.'); // Cleanup
+            }
+        }
+    });
+
 
     document.addEventListener('keydown', (event) => {
         if (event.key === 'Escape') {
+            // console.log('[DMM] Escape key pressed.'); // Cleanup
             let modalIsOpen = false;
             document.querySelectorAll('.modal-overlay').forEach(modal => {
                 if (modal.style.display === 'flex' || modal.style.display === 'block') {
@@ -151,6 +207,24 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             if(modalIsOpen && modalBackdrop && modalBackdrop.style.display === 'block'){
                 modalBackdrop.style.display = 'none';
+            }
+        }
+    });
+
+    // Add listener for messages from iframes (e.g., chatbot)
+    window.addEventListener('message', (event) => {
+        // console.log('[DMM] Message received from iframe/window:', event.data, 'from origin:', event.origin); // Cleanup
+        // Consider checking event.origin for security if the source is known e.g.
+        // if (event.origin !== window.location.origin) return; // Be careful with cross-origin iframes if URL isn't static
+        if (event.data === 'closeChatbotModal') {
+            // console.log('[DMM] "closeChatbotModal" message received. Attempting to close chatbot-modal.'); // Cleanup
+            const chatbotModal = document.getElementById('chatbot-modal');
+            // Check if the modal exists and is currently displayed
+            if (chatbotModal && (chatbotModal.style.display === 'flex' || chatbotModal.style.display === 'block')) {
+                // console.log('[DMM] Chatbot modal found and is visible. Closing it.'); // Cleanup
+                window.closeModal(chatbotModal);
+            } else {
+                // console.warn('[DMM] Chatbot modal not found or not visible. Cannot close.'); // Cleanup
             }
         }
     });

--- a/js/mobile-fab-nav.js
+++ b/js/mobile-fab-nav.js
@@ -71,11 +71,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Close FAB menus if clicking outside
     document.addEventListener('click', (event) => {
+        const isMobileNavActive = mobileNav && mobileNav.classList.contains('active');
+        const isServicesMenuActive = servicesMenu && servicesMenu.classList.contains('active');
+
         // Close main FAB nav if click is outside nav and toggle
-        if (mobileNav && mobileNav.classList.contains('active')) {
-            if (!mobileNav.contains(event.target) && fabToggle && !fabToggle.contains(event.target)) {
+        if (isMobileNavActive) {
+            const clickedInsideNav = mobileNav.contains(event.target);
+            const clickedOnFabToggle = fabToggle && fabToggle.contains(event.target);
+
+            if (!clickedInsideNav && !clickedOnFabToggle) {
+                // console.log('[MFN] Clicked outside main mobile nav and its toggle. Closing main nav.'); // Cleanup
                 mobileNav.classList.remove('active');
-                if(fabToggle) {
+                if (fabToggle) {
                     fabToggle.setAttribute('aria-expanded', 'false');
                     const icon = fabToggle.querySelector('i');
                     if (icon) {
@@ -91,12 +98,65 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
         }
-        // Separately, close services menu if click is outside services menu and its toggle (and not inside main FAB nav)
-        if (servicesMenu && servicesMenu.classList.contains('active')) {
-             if (!servicesMenu.contains(event.target) && servicesToggle && !servicesToggle.contains(event.target) && mobileNav && !mobileNav.contains(event.target)) {
+        // Separately, close services menu if click is outside services menu and its toggle
+        // This logic should consider if the click was inside the main mobileNav, as servicesMenu is often triggered from within mobileNav
+        if (isServicesMenuActive) {
+            const clickedInsideServicesMenu = servicesMenu.contains(event.target);
+            const clickedOnServicesToggle = servicesToggle && servicesToggle.contains(event.target);
+
+            // If the click is outside the services menu itself AND outside its toggle button
+            if (!clickedInsideServicesMenu && !clickedOnServicesToggle) {
+                // Further check: if the main mobile nav is still open and the click was inside it,
+                // the services menu might not need to close, depending on desired UX.
+                // For now, if click is outside services menu & its toggle, it closes.
+                // console.log('[MFN] Clicked outside services menu and its toggle. Closing services menu.'); // Cleanup
                 servicesMenu.classList.remove('active');
                 servicesMenu.setAttribute('aria-hidden', 'true');
-                if(servicesToggle) servicesToggle.setAttribute('aria-expanded', 'false');
+                if (servicesToggle) servicesToggle.setAttribute('aria-expanded', 'false');
+            }
+        }
+    });
+
+    // Add ESC key listener for closing mobile FAB nav and its sub-menu
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+            const isMobileNavActive = mobileNav && mobileNav.classList.contains('active');
+            const isServicesMenuActive = servicesMenu && servicesMenu.classList.contains('active');
+
+            if (isMobileNavActive || isServicesMenuActive) {
+                // Check if a modal is open. If so, let the modal's ESC handler take precedence.
+                const anyModalOpen = Array.from(document.querySelectorAll('.modal-overlay')).some(
+                    modal => modal.style.display === 'flex' || modal.style.display === 'block'
+                );
+
+                if (!anyModalOpen) {
+                    if (isServicesMenuActive) {
+                        servicesMenu.classList.remove('active');
+                        servicesMenu.setAttribute('aria-hidden', 'true');
+                        if (servicesToggle) servicesToggle.setAttribute('aria-expanded', 'false');
+                        // Typically, closing a submenu should not automatically close its parent menu
+                        // unless that's the desired UX. Here, we allow the main nav to remain.
+                        // If the main nav should also close, additional logic is needed.
+                        // For now, ESC will close the topmost active FAB menu element.
+                    } else if (isMobileNavActive) { // Only close main nav if service menu wasn't the target
+                        mobileNav.classList.remove('active');
+                        if (fabToggle) {
+                            fabToggle.setAttribute('aria-expanded', 'false');
+                            const icon = fabToggle.querySelector('i');
+                            if (icon) {
+                                icon.classList.remove('fa-times');
+                                icon.classList.add('fa-bars');
+                            }
+                        }
+                        // If services menu was open INSIDE mobileNav, it's already handled by the click-outside logic
+                        // or if we want explicit close:
+                        // if (servicesMenu && servicesMenu.classList.contains('active')) {
+                        //     servicesMenu.classList.remove('active');
+                        //     servicesMenu.setAttribute('aria-hidden', 'true');
+                        //     if(servicesToggle) servicesToggle.setAttribute('aria-expanded', 'false');
+                        // }
+                    }
+                }
             }
         }
     });


### PR DESCRIPTION
This commit addresses issues and implements enhancements for modal and FAB closing mechanisms:

- Corrects the "click outside" (overlay click) behavior for all modals by refining the event listener in `dynamic-modal-manager.js`.
- Adds "Send" buttons to all service modals (Business Operations, Contact Center, IT Support, Professionals). Clicking these buttons will now close the respective modal (placeholder for future data submission logic).
- Verifies and ensures the Chatbot modal closes when its internal "Send" button is clicked, utilizing `postMessage` communication.
- Confirms that X and ESC key close mechanisms are functioning as expected.
- Ensures "click outside" for the mobile horizontal navigation menu is working.

All temporary diagnostic console.log statements have been commented out.