### PR TITLE
Add PWA support with manifest and service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <!-- Link to component-specific CSS if/when created, e.g., components/join-us/join-us.css -->
     <link rel="stylesheet" href="components/join-us/join-us.css"> <!-- Linking join-us.css as it exists -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="manifest" href="manifest.json">
 </head>
 <body class="dark"> <!-- Default to dark, global-toggles.js will adjust -->
 
@@ -297,6 +298,7 @@
       <button data-modal-target="it-support-modal" data-modal-source="components/service-modals/it-support.html" data-en="IT Support" data-es="Soporte Tecnico">IT Support</button>
       <button data-modal-target="professionals-modal" data-modal-source="components/service-modals/professionals.html" data-en="Professionals" data-es="Profesionales">Professionals</button>
     </div>
+    <script src="js/sw-register.js" defer></script>
     <script src="js/sample-interactions.js" defer></script>
 </body>
 </html>

--- a/js/sw-register.js
+++ b/js/sw-register.js
@@ -1,0 +1,7 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(err => {
+      console.error('Service worker registration failed:', err);
+    });
+  });
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "OPS Online Support",
+  "short_name": "OPS",
+  "icons": [
+    {
+      "src": "icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/index.html",
+  "display": "standalone"
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,18 @@
+const CACHE_NAME = 'ops-cache-v1';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add `manifest.json` for PWA configuration
- link manifest in `index.html`
- create `sw.js` with install & fetch handlers for caching
- register service worker via new `js/sw-register.js`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686bff85eaa8832b99cf311010c52bc4