### PR TITLE
Add configurable chat API endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,6 +297,7 @@
       <button data-modal-target="it-support-modal" data-modal-source="components/service-modals/it-support.html" data-en="IT Support" data-es="Soporte Tecnico">IT Support</button>
       <button data-modal-target="professionals-modal" data-modal-source="components/service-modals/professionals.html" data-en="Professionals" data-es="Profesionales">Professionals</button>
     </div>
+    <script src="js/config.js"></script>
     <script src="js/sample-interactions.js" defer></script>
 </body>
 </html>

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,4 @@
+// js/config.js
+// Set the API endpoint for the chatbot. Update this value to point to your backend service.
+// Example: window.CHAT_API_URL = 'https://api.yourdomain.com/chat';
+window.CHAT_API_URL = 'https://api.example.com/chat';

--- a/js/sample-interactions.js
+++ b/js/sample-interactions.js
@@ -2,6 +2,9 @@
 const qs=(sel,ctx=document)=>ctx.querySelector(sel);
 const qsa=(sel,ctx=document)=>[...ctx.querySelectorAll(sel)];
 
+// Endpoint for the chatbot API. Set window.CHAT_API_URL in config.js to override.
+const CHAT_API_URL = window.CHAT_API_URL || 'https://api.example.com/chat';
+
 /* ---------- Modal open/close ---------- */
 // New modal triggers based on data-modal attribute
 qsa('[data-modal]').forEach(btn => {
@@ -179,8 +182,8 @@ if (chatLog && chatInput && chatBotForm && chatSendBtn && humanChk) {
         chatInput.value = '';
         addChatMsg('…', 'bot'); // Thinking indicator
         try {
-            // Using a placeholder URL as the sample did. Replace with actual endpoint.
-            const r = await fetch('https://example.com/api/chat', {
+            // Send chat messages to your backend. Configure CHAT_API_URL in config.js.
+            const r = await fetch(CHAT_API_URL, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ message: msg })


### PR DESCRIPTION
## Summary
- create `config.js` for backend endpoint configuration
- load `config.js` in `index.html`
- use configurable `CHAT_API_URL` in `sample-interactions.js`

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c0183a28c832b9ea3676e0d2dee36