### PR TITLE
Fix: Ensure FABs are hidden on mobile and mobile nav is mobile-only

### DIFF
--- a/css/small-screen.css
+++ b/css/small-screen.css
@@ -22,6 +22,11 @@
     display: none;
   }
   */
+
+  /* Hide the main FAB stack on mobile screens */
+  .fab-stack {
+    display: none;
+  }
 }
 
 /* Styles for screens wider than 768px (typical desktop) */


### PR DESCRIPTION
- Modified CSS to hide the Floating Action Button (FAB) stack on mobile screens (<= 768px).
- Verified that existing CSS correctly hides all mobile navigation elements on desktop screens (>= 769px) and allows them to be displayed only on mobile screens.