### PR TITLE
Refresh Chatbot, JoinUs, ContactUs modals; apply new color scheme

### DIFF
--- a/css/fab-modal.css
+++ b/css/fab-modal.css
@@ -1,16 +1,24 @@
 /*************  CSS VARIABLES  *************/
 :root{
-  --clr-primary:#007bff;
-  --clr-primary-dark:#005dc9;
-  --clr-accent:#ae7cff;
-  --clr-bg:#fff;
-  --clr-bg-dark:#222;
-  --clr-text:#333;
-  --clr-text-dark:#eee;
+  /* New color scheme from Chatbot snippet */
+  --clr-primary:#00c4ff;
+  --clr-accent :#ff3bdb;
+  --clr-accent-dark:#e000be; /* Added from chatbot styles for completeness */
+  --clr-bg  :#ffffff;
+  --clr-bg-dark:#121212;
+  --clr-tx  :#333333;
+  --clr-tx-dark:#f0f0f0;
+
+  /* Existing variables, check if still needed or can be aliased/removed later */
+  --clr-primary-old:#007bff; /* Renamed for clarity during transition */
+  --clr-primary-dark-old:#005dc9; /* Renamed */
+  --clr-accent-old:#ae7cff; /* Renamed */
+
   --fab-size:56px;
 }
-body{margin:0;font-family:'Segoe UI',Arial,sans-serif;background:var(--clr-bg);color:var(--clr-text);transition:background .3s}
-body.dark{--clr-bg:#121212;--clr-text:#eee}
+/* Updated body styles to use new color scheme */
+body{margin:0;font-family:'Segoe UI',Arial,sans-serif;background:var(--clr-bg);color:var(--clr-tx);transition:background .3s, color .3s}
+body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 
 /*************  FAB STACK  *************/
 .fab-stack{position:fixed;bottom:20px;right:20px;display:flex;flex-direction:column;align-items:center;gap:10px;z-index:5000}
@@ -53,36 +61,385 @@ body.dark{--clr-bg:#121212;--clr-text:#eee}
 .close-modal{font-size:1.5rem;background:none;border:none;cursor:pointer;color:inherit}
 body.dark .modal-content{background:#1e1e1e;color:#eee}
 
-/*************  SHARED INPUT STYLES  *************/
-input,textarea,select{width:100%;padding:.6rem;margin-top:.2rem;border-radius:6px;border:1px solid #ccc;font-size:1rem;background:var(--clr-bg);color:inherit}
+/*************  SHARED INPUT STYLES (Revised - some might be overridden by specific modal styles below) *************/
+input,textarea,select{width:100%;padding:.6rem;margin-top:.2rem;border-radius:6px;border:1px solid #ccc;font-size:1rem;background:var(--clr-bg);color:var(--clr-tx); box-sizing: border-box;}
 textarea{resize:vertical}
+body.dark input, body.dark textarea, body.dark select {
+    background-color: #333; /* General dark input background */
+    color: var(--clr-tx-dark);
+    border-color: #555;
+}
 
-/*************  JOIN MODAL (rich form)  *************/
-.form-pairs{display:grid;grid-template-columns:1fr 1fr;gap:1.3rem 2rem}
-@media(max-width:800px){.form-pairs{grid-template-columns:1fr}}
-.form-section{border:1px solid #ddd;padding:1rem;border-radius:8px;background:#f9f9f9;display:flex;flex-direction:column;gap:.6rem}
-.form-section.completed{border-color:#28a745}
-.section-header{display:flex;justify-content:space-between;align-items:center}
-.circle-btn{width:28px;height:28px;border-radius:50%;border:none;background:var(--clr-primary);color:#fff;font-weight:bold;cursor:pointer;font-size:1.2rem;margin-left:.4rem}
-.circle-btn.remove{background:#dc3545}
-.accept-btn,.edit-btn{background:#28a745;color:#fff;padding:.4rem 1rem;border:none;border-radius:4px;font-size:.9rem;cursor:pointer;margin-top:.3rem}
-.edit-btn{background:#ffc107;color:#000}
-.form-section.completed h2::after{content:" ✅";font-size:1rem;color:#28a745}
+/*************  JOIN MODAL (New Styles) *************/
+/* Styles specific to #joinModal content */
+#joinModal .modal-content {
+  /* background: #fff; Replaced by var(--clr-bg) from .modal-content base */
+  padding: 2rem;
+  max-width: 800px;
+  /* border-radius: 10px; from .modal-content base */
+  position: relative; /* Already in .modal-content */
+  overflow-y: auto; /* Already in .modal-content */
+  max-height: 90vh;
+  /* box-shadow: 0 8px 40px rgba(0,0,0,0.18); from .modal-content base */
+}
 
-/*************  CONTACT MODAL  *************/
-.form-row{display:flex;flex-wrap:wrap;gap:1rem}
-.form-cell{flex:1 1 48%;display:flex;flex-direction:column}
-@media(max-width:600px){.form-cell{flex:1 1 100%}}
+#joinModal .modal-header { /* Overrides generic .modal-header for this modal if needed */
+  margin-bottom: 1.2rem;
+}
 
-/*************  CHATBOT  *************/
-#chatbot-container{width:295px;height:540px;background:#2e1852;border-radius:18px;border:2px solid var(--clr-accent);box-shadow:0 8px 32px #0006;display:flex;flex-direction:column;overflow:hidden}
-#chatbot-header{background:var(--clr-accent);color:#fff;padding:1rem;font-weight:bold;font-size:1.25rem;text-align:center}
-#chat-log{flex:1;padding:1rem;overflow-y:auto;background:#1b0e2d;color:#fff;font-size:1rem}
-.chat-msg{margin-bottom:.7rem}.user{text-align:right;color:#e7e7e7}.bot{text-align:left;color:var(--clr-accent)}
-#chatbot-form-container{background:#220f3a;border-top:1px solid var(--clr-accent);padding:.5rem}
-#chatbot-input-row{display:flex;margin-bottom:.5rem}
-#chatbot-input{flex:1;padding:.7rem;border:none;background:transparent;color:#fff;font-size:1rem}
-#chatbot-send{background:var(--clr-accent);border:none;color:#fff;font-weight:bold;padding:0 1.2rem;cursor:pointer}
+#joinModal .lang-toggle, #joinModal #theme-toggle {
+  position: absolute;
+  top: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  user-select: none;
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  color: var(--clr-tx); /* Use text color variable */
+}
+#joinModal .lang-toggle {
+  right: 4rem;
+  font-size: 0.9rem;
+}
+#joinModal #theme-toggle { /* ID for theme toggle within join modal */
+  right: 1rem;
+  font-size: 1.2rem;
+}
+
+#joinModal .form-section {
+  border: 1px solid #ddd;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  border-radius: 8px;
+  background: #f9f9f9; /* Light theme section background */
+  display: flex; /* Added from old styles, useful */
+  flex-direction: column; /* Added from old styles */
+  gap: 0.5rem; /* Added from new snippet's .form-row/.form-section */
+}
+
+#joinModal .section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+#joinModal .section-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+#joinModal .circle-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background-color: var(--clr-primary); /* Use new primary color */
+  color: white;
+  font-weight: bold;
+  cursor: pointer;
+  margin-left: 0.5rem;
+  font-size: 1.2rem;
+}
+#joinModal .circle-btn.remove { background-color: #dc3545; } /* Standard red for remove */
+
+#joinModal .inputs input { /* Styling for dynamically added inputs */
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  margin: 0.5rem 0;
+  box-sizing: border-box;
+  background: var(--clr-bg); /* Ensure inputs inside sections also use theme colors */
+  color: var(--clr-tx);
+  border: 1px solid #ccc;
+}
+
+#joinModal .accept-btn,
+#joinModal .edit-btn {
+  background-color: #28a745; /* Standard green for accept */
+  color: white;
+  padding: 0.4rem 1rem;
+  border: none;
+  margin-top: 0.5rem;
+  cursor: pointer;
+  border-radius: 4px;
+  margin-right: 0.5rem;
+  font-size: 0.9rem;
+}
+#joinModal .edit-btn {
+  background-color: #ffc107; /* Standard yellow for edit */
+  color: #000;
+}
+
+#joinModal .completed h2 { color: green; }
+#joinModal .completed h2::after { content: " ✅"; font-size: 1rem; }
+
+#joinModal .submit-button { /* Specific submit button for Join Us form */
+  padding: 0.6rem 1.2rem;
+  background: var(--clr-primary); /* Use new primary color */
+  border: none;
+  color: white; /* Text on primary button often white or dark if primary is light */
+  cursor: pointer;
+  border-radius: 4px;
+}
+#joinModal .submit-button:hover {
+    background: var(--clr-accent);
+}
+
+
+#joinModal .form-footer { text-align: right; margin-top: 2rem; }
+
+/* .form-row is a generic class, ensure it's styled correctly for joinModal if used */
+#joinModal .form-row {
+    margin-bottom: 1rem;
+    display: flex; /* Added from new snippet */
+    flex-direction: column; /* Added from new snippet */
+    gap: 0.5rem; /* Added from new snippet */
+}
+#joinModal label { font-weight: bold; } /* General label style within Join modal */
+
+/* Inputs directly under .form-row in #joinModal */
+#joinModal .form-row > input[type="text"],
+#joinModal .form-row > input[type="email"],
+#joinModal .form-row > input[type="tel"],
+#joinModal .form-row > textarea {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.3rem;
+  box-sizing: border-box;
+  background: var(--clr-bg);
+  color: var(--clr-tx);
+  border: 1px solid #ccc;
+}
+#joinModal .form-row > textarea { resize: vertical; }
+
+
+/* Responsive tweaks for #joinModal */
+@media (max-width: 600px) {
+  #joinModal .modal-content { padding: 1rem; /* max-width: 98vw; Potentially remove if base modal is ok */ }
+  #joinModal .lang-toggle, #joinModal #theme-toggle {
+    top: 0.8rem;
+    padding: 0.4rem;
+  }
+  #joinModal .lang-toggle {
+    right: 3.8rem;
+    font-size: 0.85rem;
+  }
+  #joinModal #theme-toggle {
+    right: 0.8rem;
+    font-size: 1.1rem;
+  }
+}
+
+/* Dark Mode Styles for #joinModal, using body.dark */
+body.dark #joinModal .modal-content {
+  background: #1e1e1e; /* Specific dark background for this modal's content */
+  color: var(--clr-tx-dark);
+  /* box-shadow: 0 8px 40px rgba(255,255,255,0.1); Should be inherited or set on base .modal-content.dark */
+}
+body.dark #joinModal .form-section {
+  background: #2c2c2c;
+  border-color: #444;
+}
+/* Dark mode for inputs within .inputs div and direct .form-row children */
+body.dark #joinModal .inputs input,
+body.dark #joinModal .form-row > input[type="text"],
+body.dark #joinModal .form-row > input[type="email"],
+body.dark #joinModal .form-row > input[type="tel"],
+body.dark #joinModal .form-row > textarea {
+  background-color: #333;
+  color: var(--clr-tx-dark);
+  border-color: #555;
+}
+body.dark #joinModal .circle-btn {
+  background-color: var(--clr-primary); /* Dark mode primary button */
+}
+body.dark #joinModal .circle-btn.remove {
+  background-color: #b22222; /* Dark mode remove button */
+}
+body.dark #joinModal .accept-btn {
+  background-color: #1e7e34; /* Dark mode accept button */
+}
+body.dark #joinModal .edit-btn {
+  background-color: #d39e00; /* Dark mode edit button */
+  color: #121212; /* Text color for edit button in dark mode */
+}
+body.dark #joinModal .submit-button {
+  background-color: var(--clr-primary); /* Dark mode submit button */
+}
+body.dark #joinModal .submit-button:hover {
+  background-color: var(--clr-accent);
+}
+body.dark #joinModal .completed h2 {
+  color: #4caf50; /* Dark mode completed text */
+}
+body.dark #joinModal .lang-toggle, body.dark #joinModal #theme-toggle, body.dark #joinModal .close-modal {
+  color: var(--clr-tx-dark); /* Ensure controls are visible in dark mode */
+}
+
+/* Form Grid specific to Join Us */
+#joinModal .form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+#joinModal .full-width { /* Utility class for items spanning full grid width */
+  grid-column: 1 / -1;
+}
+/* Form sections within the grid */
+#joinModal .form-grid .form-section {
+    margin-bottom: 0; /* Remove bottom margin if gap is handled by grid */
+}
+
+@media (max-width: 768px) {
+  #joinModal .form-grid {
+    grid-template-columns: 1fr; /* Single column on smaller screens */
+  }
+}
+
+
+/*************  CONTACT MODAL (New Styles) *************/
+/* Styles specific to #contactModal */
+/* Base .modal-overlay and .modal-content are already defined.
+   The new snippet's .modal-content styles will be applied via #contactModal .modal-content if they differ. */
+
+#contactModal .modal-content {
+  /* background: #fff; -- Inherits from base .modal-content */
+  /* border-radius: 12px; -- Inherits */
+  width: 90%; /* Can override base if needed */
+  max-width: 600px; /* Specific max-width for contact modal */
+  padding: 1.5rem; /* Specific padding */
+  /* box-shadow: 0 0 20px rgba(0, 0, 0, 0.2); -- Inherits or can be overridden */
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; /* Specific font stack */
+}
+
+#contactModal .modal-header,
+#contactModal .modal-footer {
+  /* display: flex; justify-content: space-between; align-items: center; -- Inherits from base */
+  margin-bottom: 1rem; /* Consistent margin */
+}
+
+#contactModal .modal-header h3 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--clr-tx); /* Use theme text color */
+}
+
+/* .close-modal is already styled globally. If #contactModal needs a different one, specify here. */
+/* #contactModal .close-modal { ... } */
+
+#contactModal .modal-body {
+  margin-bottom: 1rem;
+}
+
+#contactModal form { /* Styles for the form within #contactModal */
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+#contactModal .form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+#contactModal .form-cell {
+  flex: 1 1 48%;
+  display: flex;
+  flex-direction: column;
+}
+
+#contactModal label {
+  margin-bottom: 0.3rem;
+  font-weight: 600;
+  color: var(--clr-tx); /* Use theme text color */
+}
+
+/* General input, select, textarea styles within #contactModal, inherits from shared but can override */
+#contactModal input,
+#contactModal select,
+#contactModal textarea {
+  padding: 0.6rem;
+  /* border: 1px solid #ccc; -- Inherited from shared input styles */
+  /* border-radius: 6px; -- Inherited */
+  font-size: 1rem; /* Consistent font size */
+  /* background: var(--clr-bg); -- Inherited */
+  /* color: var(--clr-tx); -- Inherited */
+}
+
+#contactModal textarea {
+  resize: vertical; /* Specific to textarea */
+}
+
+#contactModal .submit-button { /* Specific submit button for Contact Us form */
+  padding: 0.75rem 1.5rem;
+  background-color: var(--clr-primary); /* Use new primary color */
+  color: #fff; /* Text color on button */
+  font-weight: bold;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+#contactModal .submit-button:hover {
+  background-color: var(--clr-accent); /* Use accent for hover */
+}
+
+@media (max-width: 600px) {
+  #contactModal .form-cell {
+    flex: 1 1 100%; /* Full width cells on small screens */
+  }
+}
+
+/* Dark Mode for #contactModal */
+body.dark #contactModal .modal-content {
+  background: #1e1e1e; /* Dark background for contact modal content */
+  color: var(--clr-tx-dark);
+}
+body.dark #contactModal .modal-header h3 {
+  color: var(--clr-tx-dark);
+}
+body.dark #contactModal label {
+  color: var(--clr-tx-dark);
+}
+/* Dark mode for inputs, selects, textareas in #contactModal, inherits from shared dark input styles but can be more specific */
+body.dark #contactModal input,
+body.dark #contactModal select,
+body.dark #contactModal textarea {
+  /* background-color: #333; -- Inherited */
+  /* color: var(--clr-tx-dark); -- Inherited */
+  /* border-color: #555; -- Inherited */
+}
+body.dark #contactModal .submit-button {
+  background-color: var(--clr-primary); /* Primary color for dark mode button */
+}
+body.dark #contactModal .submit-button:hover {
+  background-color: var(--clr-accent); /* Accent color for dark mode button hover */
+}
+
+
+/*************  CHATBOT (New Styles) *************/
+#chatbot-container{width:300px;height:540px;background:#251541;border:2px solid var(--clr-accent);
+  border-radius:18px;box-shadow:0 8px 32px #0006;display:flex;flex-direction:column;overflow:hidden}
+#chatbot-header{display:flex;justify-content:space-between;align-items:center;gap:.5rem;
+  background:linear-gradient(135deg,var(--clr-primary) 0%,var(--clr-accent) 100%);
+  color:#fff;font-weight:600;font-size:1.1rem;padding:.75rem 1rem}
+#chatbot-header .ctrl{cursor:pointer;font-size:.75rem;font-weight:500;user-select:none;opacity:.85}
+#chatbot-header .ctrl:hover{opacity:1}
+#chat-log{flex:1;overflow-y:auto;padding:1rem;background:#1b0e2d;color:#eee;font-size:.94rem}
+.chat-msg{margin:.5rem 0;max-width:90%} /* Applied to both user and bot messages */
+.chat-msg.user{margin-left:auto;background:var(--clr-primary);color:#000;padding:.5rem .7rem;border-radius:14px 14px 0 14px}
+.chat-msg.bot {margin-right:auto;background:#321b53;color:#fff;padding:.5rem .7rem;border-radius:14px 14px 14px 0}
+#chatbot-form-container{background:#220f3a;border-top:1px solid var(--clr-accent);padding:.55rem .7rem}
+#chatbot-input-row{display:flex;gap:.6rem} /* This is the form element in the new HTML */
+#chatbot-input{flex:1;background:transparent;border:none;color:#fff;font-size:.95rem;padding:.55rem .6rem}
+#chatbot-send{display:flex;align-items:center;gap:6px;background:var(--clr-accent);border:none;color:#fff;
+  font-weight:600;padding:.5rem .9rem;border-radius:8px;cursor:pointer;transition:.3s}
+#chatbot-send i{transition:transform .3s}
+#chatbot-send:hover i{transform:rotate(-45deg)}
 #chatbot-send:disabled{background:#555;cursor:not-allowed}
-.human-check{color:#ddd;font-size:.9rem;display:flex;align-items:center}.human-check input{margin-right:.5rem}
-@media(max-width:600px){#chatbot-container{height:45vhvh;width:85%}}
+.human-check{color:#ddd;font-size:.85rem;display:flex;align-items:center;margin-top:.3rem} /* Applied to the label wrapping checkbox and span */
+.human-check input{margin-right:.4rem}
+@media(max-width:480px){#chatbot-container{height:75vh;width:90%}}

--- a/index.html
+++ b/index.html
@@ -158,104 +158,274 @@
     <a href="professionals.html"       data-en="Professionals"       data-es="Profesionales">Professionals</a>
   </div>
 
-  <!-- ===== JOIN MODAL ===== -->
-  <div class="modal-overlay" id="joinModal" role="dialog" aria-modal="true" aria-labelledby="joinTitle">
-    <div class="modal-content">
+  <!-- ===== JOIN MODAL (New HTML Structure) ===== -->
+  <div class="modal-overlay" id="joinModal" role="dialog" aria-modal="true" aria-labelledby="joinModalSTitle"> <!-- Changed aria-labelledby to avoid conflict if old title was used by JS -->
+    <div class="modal-content" id="modal-content"> <!-- ID from new snippet, might be generic -->
+      <button id="theme-toggle" aria-label="Toggle theme" data-aria-label-en="Toggle theme" data-aria-label-es="Cambiar tema">🌓</button>
+      <button class="lang-toggle" onclick="toggleLang()" data-aria-label-en="Toggle language" data-aria-label-es="Cambiar idioma">EN | ES</button> <!-- Assuming toggleLang() will be defined -->
       <div class="modal-header">
-        <h2 id="joinTitle" data-en="Join Us" data-es="Únase">Join Us</h2>
-        <button class="close-modal" data-close>&times;</button>
+        <h3 id="joinModalSTitle" data-en="Join Us" data-es="Únete a Nosotros">Join Us</h3> <!-- New ID for title -->
+        <button class="close-modal" id="close-modal-btn" data-close aria-label="Close" data-aria-label-en="Close" data-aria-label-es="Cerrar">&times;</button> <!-- Added data-close for existing JS compatibility -->
       </div>
-      <form id="joinForm" autocomplete="off">
-        <div class="form-pairs">
-          <!-- Row 1 -->
-          <div class="form-block"><label for="jn-name" data-en="Name" data-es="Nombre">Name</label><input id="jn-name" name="name" type="text" required placeholder="Enter your name" data-en="Enter your name" data-es="Ingrese su nombre"></div>
-          <div class="form-block"><label for="jn-email" data-en="Email" data-es="Correo">Email</label><input id="jn-email" name="email" type="email" required placeholder="Enter your email" data-en="Enter your email" data-es="Ingrese su correo"></div>
-          <!-- Row 2 -->
-          <div class="form-block"><label for="jn-phone" data-en="Phone" data-es="Teléfono">Phone</label><input id="jn-phone" name="phone" type="tel" required placeholder="Enter your phone" data-en="Enter your phone" data-es="Ingrese su teléfono"></div>
-          <div></div>
-          <!-- Row 3+ -->
-          <div class="form-section" data-section="Skills">
-            <div class="section-header"><h2 data-en="Skills" data-es="Habilidades">Skills</h2><div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div></div>
-            <div class="inputs"></div><button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button><button type="button" class="edit-btn" style="display:none;" data-en="Edit" data-es="Editar">Edit</button>
+
+      <form id="join-form" autocomplete="off"> <!-- ID matches new JS snippet -->
+        <div class="form-grid">
+          <!-- Left Column in grid (as per snippet structure, though it's one column effectively here) -->
+          <div class="form-row"> <!-- This div wraps basic contact info -->
+            <label for="name" data-en="Name" data-es="Nombre">Name</label>
+            <input type="text" id="name" name="name" required
+              data-placeholder-en="Enter your name"
+              data-placeholder-es="Ingresa tu nombre"
+              placeholder="Enter your name" />
+
+            <label for="email" data-en="Email" data-es="Correo Electrónico">Email</label>
+            <input type="email" id="email" name="email" required
+              data-placeholder-en="Enter your email"
+              data-placeholder-es="Ingresa tu correo"
+              placeholder="Enter your email" />
+
+            <label for="phone" data-en="Phone" data-es="Teléfono">Phone</label>
+            <input type="tel" id="phone" name="phone" required
+              data-placeholder-en="Enter your phone"
+              data-placeholder-es="Ingresa tu teléfono"
+              placeholder="Enter your phone" />
           </div>
-          <div class="form-section" data-section="Education">
-            <div class="section-header"><h2 data-en="Education" data-es="Educación">Education</h2><div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div></div>
-            <div class="inputs"></div><button type="button" class="accept-btn">Accept</button><button type="button" class="edit-btn" style="display:none;">Edit</button>
-          </div>
-          <div class="form-section" data-section="Certification">
-            <div class="section-header"><h2 data-en="Certification" data-es="Certificación">Certification</h2><div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div></div>
-            <div class="inputs"></div><button type="button" class="accept-btn">Accept</button><button type="button" class="edit-btn" style="display:none;">Edit</button>
-          </div>
-          <div class="form-section" data-section="Hobbies">
-            <div class="section-header"><h2 data-en="Hobbies" data-es="Pasatiempos">Hobbies</h2><div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div></div>
-            <div class="inputs"></div><button type="button" class="accept-btn">Accept</button><button type="button" class="edit-btn" style="display:none;">Edit</button>
-          </div>
-          <div class="form-section">
+
+          <!-- Right Column in grid (for form sections) -->
+          <div class="form-sections"> <!-- Wrapper for all form-section elements -->
+            <div class="form-section" data-section="Skills">
+              <div class="section-header">
+                <h2 data-en="Skills" data-es="Habilidades">Skills</h2>
+                <div>
+                  <button type="button" class="circle-btn add">+</button>
+                  <button type="button" class="circle-btn remove">−</button>
+                </div>
+              </div>
+              <div class="inputs"></div>
+              <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+              <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display:none;">Edit</button>
+            </div>
+
+            <div class="form-section" data-section="Education">
+              <div class="section-header">
+                <h2 data-en="Education" data-es="Educación">Education</h2>
+                <div>
+                  <button type="button" class="circle-btn add">+</button>
+                  <button type="button" class="circle-btn remove">−</button>
+                </div>
+              </div>
+              <div class="inputs"></div>
+              <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+              <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display:none;">Edit</button>
+            </div>
+
+            <div class="form-section" data-section="Continued Education">
+              <div class="section-header">
+                <h2 data-en="Continued Education" data-es="Educación Continua">Continued Education</h2>
+                <div>
+                  <button type="button" class="circle-btn add">+</button>
+                  <button type="button" class="circle-btn remove">−</button>
+                </div>
+              </div>
+              <div class="inputs"></div>
+              <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+              <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display:none;">Edit</button>
+            </div>
+
+            <div class="form-section" data-section="Certification">
+              <div class="section-header">
+                <h2 data-en="Certification" data-es="Certificación">Certification</h2>
+                <div>
+                  <button type="button" class="circle-btn add">+</button>
+                  <button type="button" class="circle-btn remove">−</button>
+                </div>
+              </div>
+              <div class="inputs"></div>
+              <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+              <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display:none;">Edit</button>
+            </div>
+
+            <div class="form-section" data-section="Hobbies">
+              <div class="section-header">
+                <h2 data-en="Hobbies" data-es="Pasatiempos">Hobbies</h2>
+                <div>
+                  <button type="button" class="circle-btn add">+</button>
+                  <button type="button" class="circle-btn remove">−</button>
+                </div>
+              </div>
+              <div class="inputs"></div>
+              <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+              <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display:none;">Edit</button>
+            </div>
+
+            <div class="form-section" data-section="Experience">
+              <div class="section-header">
+                <h2 data-en="Experience" data-es="Experiencia">Experience</h2>
+                <div>
+                  <button type="button" class="circle-btn add">+</button>
+                  <button type="button" class="circle-btn remove">−</button>
+                </div>
+              </div>
+              <div class="inputs"></div>
+              <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+              <button type="button" class="edit-btn" data-en="Edit" data-es="Editar" style="display:none;">Edit</button>
+            </div>
+          </div> <!-- End .form-sections -->
+        </div> <!-- End .form-grid -->
+
+        <!-- These were outside the grid in the original structure, now placing them as full-width or separate rows -->
+        <div class="form-row full-width"> <!-- Interest Dropdown, full width -->
+          <div class="form-section"> <!-- Wrapped in form-section for consistent styling if desired -->
             <h2 data-en="What are you interested about?" data-es="¿En qué está interesado?">What are you interested about?</h2>
-            <select id="jn-interest" required>
-              <option value="" disabled selected>Select an option</option>
-              <option>Business Operations</option><option>Contact Center</option><option>IT Support</option><option>Professionals</option>
-            </select>
+            <div class="form-cell"> <!-- from contact form snippet, useful for select -->
+              <select id="contact-interest" name="jn_interest" required> <!-- Changed ID/name to be unique for join form -->
+                <option value="" disabled selected>Select an option</option>
+                <option data-en="Business Operations" data-es="Gestión">Business Operations</option>
+                <option data-en="Contact Center" data-es="Centro de Servicios">Contact Center</option>
+                <option data-en="IT Support" data-es="Soporte Técnico">IT Support</option>
+                <option data-en="Professionals" data-es="Profesionales">Professionals</option>
+              </select>
+            </div>
           </div>
-          <div class="form-section" data-section="Continued Education">
-            <div class="section-header"><h2 data-en="Continued Education" data-es="Educación Continua">Continued Education</h2><div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div></div>
-            <div class="inputs"></div><button type="button" class="accept-btn">Accept</button><button type="button" class="edit-btn" style="display:none;">Edit</button>
-          </div>
-          <div class="form-section" data-section="Experience">
-            <div class="section-header"><h2 data-en="Experience" data-es="Experiencia">Experience</h2><div><button type="button" class="circle-btn add">+</button><button type="button" class="circle-btn remove">−</button></div></div>
-            <div class="inputs"></div><button type="button" class="accept-btn">Accept</button><button type="button" class="edit-btn" style="display:none;">Edit</button>
-          </div>
-          <div class="form-block"><label for="jn-comment" data-en="Tell us about yourself" data-es="Cuéntenos sobre usted">Tell us about yourself</label><textarea id="jn-comment" name="comment" rows="5" placeholder="Tell us about yourself..." data-en="Tell us about yourself..." data-es="Cuéntenos sobre usted..."></textarea></div>
         </div>
-        <div class="modal-footer"><button type="submit" class="fab-btn" data-en="Submit" data-es="Enviar">Submit</button></div>
+
+        <div class="form-row full-width"> <!-- Comments, full width -->
+          <label for="comment" data-en="Tell us about yourself" data-es="Cuéntanos sobre ti">Tell us about yourself</label>
+          <textarea id="comment" name="comment" rows="4"
+            data-placeholder-en="Tell us about yourself..."
+            data-placeholder-es="Cuéntanos sobre ti..."
+            placeholder="Tell us about yourself..."></textarea>
+        </div>
+
+        <div class="form-footer modal-footer"> <!-- Added .modal-footer for consistency if needed -->
+          <button type="submit" class="submit-button" data-en="Submit" data-es="Enviar">Submit</button>
+        </div>
       </form>
     </div>
   </div>
 
-  <!-- ===== CONTACT MODAL ===== -->
-  <div class="modal-overlay" id="contactModal" role="dialog" aria-modal="true" aria-labelledby="contactTitle">
-    <div class="modal-content">
+  <!-- ===== CONTACT MODAL (New HTML Structure) ===== -->
+  <div class="modal-overlay" id="contactModal" role="dialog" aria-modal="true" aria-labelledby="contactModalTitle">
+    <div class="modal-content"> <!-- This class is targeted by new CSS for contact modal -->
+
+      <!-- Modal Header -->
       <div class="modal-header">
-        <h2 id="contactTitle" data-en="Contact Us" data-es="Contáctenos">Contact Us</h2>
-        <button class="close-modal" data-close>&times;</button>
+        <h3 id="contactModalTitle" data-en="Contact Us" data-es="Contáctenos">Contact Us</h3>
+        <button class="close-modal" data-close aria-label="Close">&times;</button> <!-- data-close for existing JS -->
       </div>
-      <form id="contactForm">
-        <div class="form-row">
-          <div class="form-cell"><label for="ct-name" data-en="Name" data-es="Nombre">Name</label><input id="ct-name" name="name" type="text" required placeholder="Enter your name" data-en="Enter your name" data-es="Ingrese su nombre"></div>
-          <div class="form-cell"><label for="ct-email" data-en="Email" data-es="Correo Electrónico">Email</label><input id="ct-email" name="email" type="email" required placeholder="Enter your email" data-en="Enter your email" data-es="Ingrese su correo"></div>
-        </div>
-        <div class="form-row">
-          <div class="form-cell"><label for="ct-phone" data-en="Contact Number" data-es="Número de Contacto">Contact Number</label><input id="ct-phone" name="phone" type="tel" required placeholder="Enter your contact number"></div>
-          <div class="form-cell"><label for="ct-date" data-en="Preferred Date" data-es="Fecha Preferida">Preferred Date</label><input id="ct-date" name="date" type="date" required></div>
-        </div>
-        <div class="form-row">
-          <div class="form-cell"><label for="ct-time" data-en="Preferred Time" data-es="Hora Preferida">Preferred Time</label><input id="ct-time" name="time" type="time" required></div>
-          <div class="form-cell"><label for="ct-interest" data-en="What are you interested about?" data-es="¿En qué está interesado?">What are you interested about?</label>
-            <select id="ct-interest" name="interest" required>
-              <option value="" disabled selected>Select an option</option>
-              <option>Business Operations</option><option>Contact Center</option><option>IT Support</option><option>Professionals</option>
-            </select>
+
+      <!-- Modal Body -->
+      <div class="modal-body">
+        <form id="contact-form"> <!-- ID from new snippet -->
+
+          <!-- Name & Email -->
+          <div class="form-row">
+            <div class="form-cell">
+              <label for="contact-name" data-en="Name" data-es="Nombre">Name</label>
+              <input type="text" id="contact-name" name="contact_name" <!-- Changed name for uniqueness -->
+                     placeholder="Enter your name"
+                     data-en="Enter your name"
+                     data-es="Ingrese su Nombre"
+                     required>
+            </div>
+
+            <div class="form-cell">
+              <label for="contact-email" data-en="Email" data-es="Correo Electrónico">Email</label>
+              <input type="email" id="contact-email" name="contact_email" <!-- Changed name for uniqueness -->
+                     placeholder="Enter your email"
+                     data-en="Enter your email"
+                     data-es="Ingrese su correo electrónico"
+                     required>
+            </div>
           </div>
-        </div>
-        <div class="form-row">
-          <div class="form-cell" style="flex:1 1 100%"><label for="ct-comment" data-en="Comments" data-es="Comentarios">Comments</label><textarea id="ct-comment" name="comments" rows="4" placeholder="What service are you interested in?"></textarea></div>
-        </div>
-        <div class="modal-footer"><button type="submit" class="fab-btn" data-en="Send" data-es="Enviar">Send</button></div>
-      </form>
+
+          <!-- Contact Number & Date -->
+          <div class="form-row">
+            <div class="form-cell">
+              <label for="contact-number" data-en="Contact Number" data-es="Número de Contacto">Contact Number</label>
+              <input type="tel" id="contact-number" name="contact_number" <!-- Changed name -->
+                     placeholder="Enter your contact number"
+                     data-en="Enter your contact number"
+                     data-es="Ingrese su número"
+                     required>
+            </div>
+
+            <div class="form-cell">
+              <label for="contact-date" data-en="Preferred Date" data-es="Fecha Preferida">Preferred Date</label>
+              <input type="date" id="contact-date" name="contact_date" required> <!-- Changed name -->
+            </div>
+          </div>
+
+          <!-- Time & Interest Dropdown -->
+          <div class="form-row">
+            <div class="form-cell">
+              <label for="contact-time" data-en="Preferred Time" data-es="Hora Preferida">Preferred Time</label>
+              <input type="time" id="contact-time" name="contact_time" required> <!-- Changed name -->
+            </div>
+
+            <div class="form-cell">
+              <label for="contact-interest-select" data-en="What are you interested about?" data-es="¿En qué está interesado?">What are you interested about?</label> <!-- Changed ID for select -->
+              <select id="contact-interest-select" name="contact_interest" required> <!-- Changed ID and name -->
+                <option value="" disabled selected>Select an option</option>
+                <option data-en="Business Operations" data-es="Gestión">Business Operations</option>
+                <option data-en="Contact Center" data-es="Centro de Servicios">Contact Center</option>
+                <option data-en="IT Support" data-es="Soporte Técnico">IT Support</option>
+                <option data-en="Professionals" data-es="Profesionales">Professionals</option>
+              </select>
+            </div>
+          </div>
+
+          <!-- Comments -->
+          <div class="form-row">
+            <div class="form-cell" style="flex: 1 1 100%;">
+              <label for="contact-comments" data-en="Comments" data-es="Comentarios">Comments</label>
+              <textarea id="contact-comments" name="contact_comments" rows="4" <!-- Changed name -->
+                        placeholder="What service are you interested in?"
+                        data-en="What service are you interested in?"
+                        data-es="En qué servicio está interesado?"
+                        required></textarea>
+            </div>
+          </div>
+          <!-- Form submission is handled by the button in modal-footer -->
+        </form>
+      </div>
+
+      <!-- Modal Footer -->
+      <div class="modal-footer">
+        <button type="submit" form="contact-form" class="submit-button"
+                data-en="Send" data-es="Enviar">Send</button>
+      </div>
+
     </div>
   </div>
 
-  <!-- ===== CHATBOT MODAL ===== -->
-  <div class="modal-overlay" id="chatbotModal">
-    <div id="chatbot-container">
-      <div id="chatbot-header" data-en="OPS AI Chatbot" data-es="Chatbot OPS AI">OPS AI Chatbot</div>
-      <div id="chat-log"></div>
+  <!-- ===== CHATBOT MODAL (New HTML Structure) ===== -->
+  <div class="modal-overlay" id="chatbotModal"> <!-- Base overlay remains, content replaced -->
+    <div id="chatbot-container" role="dialog" aria-modal="true"> <!-- Ensure role and aria-modal are on the container if it's the dialog -->
+      <div id="chatbot-header">
+        <span id="title" data-en="OPS AI Chatbot" data-es="Chatbot OPS AI">OPS AI Chatbot</span>
+        <!-- tiny controls -->
+        <div>
+          <span id="langCtrl" class="ctrl">ES</span>
+          &nbsp;|&nbsp;
+          <span id="themeCtrl" class="ctrl">Dark</span>
+        </div>
+      </div>
+
+      <div id="chat-log" aria-live="polite"></div>
+
       <div id="chatbot-form-container">
-        <form id="chatbot-input-row" autocomplete="off">
-          <input id="chatbot-input" type="text" placeholder="Type your message..." required maxlength="256" data-en="Type your message..." data-es="Escriba su mensaje...">
-          <button id="chatbot-send" type="submit" disabled>Send</button>
+        <form id="chatbot-input-row" autocomplete="off"> <!-- ID matches new CSS and JS -->
+          <input id="chatbot-input" type="text" placeholder="Type your message..." required maxlength="256"
+                 data-en-ph="Type your message..." data-es-ph="Escriba su mensaje...">
+          <button id="chatbot-send" type="submit" disabled aria-label="Send">
+            <i class="fas fa-paper-plane"></i>
+          </button>
         </form>
-        <label class="human-check"><input type="checkbox" id="human-check"><span data-en="I am human" data-es="Soy humano">I am human</span></label>
+        <label class="human-check"> <!-- Class matches new CSS -->
+          <input type="checkbox" id="human-check"> <!-- ID matches new JS -->
+          <span id="human-label" data-en="I am human" data-es="Soy humano">I am human</span> <!-- ID matches new JS -->
+        </label>
       </div>
     </div>
   </div>

--- a/js/fab-modal.js
+++ b/js/fab-modal.js
@@ -1,62 +1,394 @@
 /* ---------- Helper ---------- */
-const qs=(sel,ctx=document)=>ctx.querySelector(sel);
-const qsa=(sel,ctx=document)=>[...ctx.querySelectorAll(sel)];
+const qs = (sel, ctx = document) => ctx.querySelector(sel);
+const qsa = (sel, ctx = document) => [...ctx.querySelectorAll(sel)];
 
-/* ---------- Modal open/close ---------- */
-qsa('[data-modal]').forEach(btn=>btn.onclick=()=>qs('#'+btn.dataset.modal).classList.add('active'));
-qsa('[data-close]').forEach(btn=>btn.onclick=()=>btn.closest('.modal-overlay').classList.remove('active'));
-window.addEventListener('click',e=>qsa('.modal-overlay.active').forEach(m=>{if(e.target===m)m.classList.remove('active')})); // click-outside
-window.addEventListener('keydown',e=>{if(e.key==='Escape')qsa('.modal-overlay.active').forEach(m=>m.classList.remove('active'))});
-
-/* ---------- Mobile nav + toggles ---------- */
-qs('#menuToggle').onclick=()=>qs('#mobileNav').classList.toggle('active');
-qs('#mobile-services-toggle').onclick=()=>qs('#mobile-services-menu').classList.toggle('active');
-qs('#mobile-language-toggle').onclick=()=>{
- const isEN=qs('#mobile-language-toggle').textContent==='EN';
- qsa('[data-en]').forEach(el=>el.textContent=isEN?el.dataset.es:el.dataset.en);
- qs('#mobile-language-toggle').textContent=isEN?'ES':'EN';
-};
-qs('#mobile-theme-toggle').onclick=()=>{
- const light=qs('#mobile-theme-toggle').textContent==='Light';
- document.body.classList.toggle('dark',light);
- qs('#mobile-theme-toggle').textContent=light?'Dark':'Light';
-};
-
-/* ---------- Join dynamic sections ---------- */
-qsa('#joinModal .form-section').forEach(section=>{
- const inputs   =qs('.inputs',section);
- const addBtn   =qs('.add',section);
- const rmBtn    =qs('.remove',section);
- const accBtn   =qs('.accept-btn',section);
- const editBtn  =qs('.edit-btn',section);
- if(!addBtn)return; // skip plain sections
- addBtn.onclick=()=>{const ip=document.createElement('input');ip.type='text';ip.placeholder=`Enter ${qs('h2',section).textContent}`;inputs.appendChild(ip);ip.focus()};
- rmBtn.onclick =()=>inputs.lastElementChild&&inputs.removeChild(inputs.lastElementChild);
- accBtn.onclick=()=>{
-   if(!inputs.children.length)return alert('Add at least one entry.');
-   inputs.querySelectorAll('input').forEach(i=>i.disabled=true);
-   section.classList.add('completed');accBtn.style.display='none';editBtn.style.display='inline-block';
- };
- editBtn.onclick=()=>{
-   inputs.querySelectorAll('input').forEach(i=>i.disabled=false);
-   section.classList.remove('completed');accBtn.style.display='inline-block';editBtn.style.display='none';
- };
+/* ---------- Generic Modal open/close (Keep this for FABs) ---------- */
+// This ensures FABs still open their respective modals
+qsa('[data-modal]').forEach(btn => {
+  const modalId = btn.dataset.modal;
+  const modal = qs('#' + modalId);
+  if (modal) {
+    btn.onclick = () => modal.classList.add('active');
+  } else {
+    console.warn(`Modal with ID #${modalId} not found for button:`, btn);
+  }
 });
 
-/* ---------- Simple submit stubs ---------- */
-qs('#joinForm').onsubmit=e=>{e.preventDefault();alert('Join form submitted');qs('#joinModal').classList.remove('active')};
-qs('#contactForm').onsubmit=e=>{e.preventDefault();alert('Contact form submitted');qs('#contactModal').classList.remove('active')};
+qsa('[data-close]').forEach(btn => {
+  btn.onclick = () => btn.closest('.modal-overlay').classList.remove('active');
+});
 
-/* ---------- Chatbot ---------- */
-const chatLog=qs('#chat-log'),chatInput=qs('#chatbot-input'),chatForm=qs('#chatbot-input-row'),sendBtn=qs('#chatbot-send'),humanChk=qs('#human-check');
-humanChk.onchange=()=>sendBtn.disabled=!humanChk.checked;
-function addMsg(text,cls){const d=document.createElement('div');d.className=`chat-msg ${cls}`;d.textContent=text;chatLog.appendChild(d);chatLog.scrollTop=chatLog.scrollHeight;}
-chatForm.onsubmit=async e=>{
- e.preventDefault();if(!humanChk.checked)return;
- const msg=chatInput.value.trim();if(!msg)return;
- addMsg(msg,'user');chatInput.value='';addMsg('…','bot');
- try{
-   const r=await fetch('https://your-cloudflare-worker.example.com/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:msg})});
-   const d=await r.json();chatLog.lastChild.textContent=d.reply||'No reply.';
- }catch{chatLog.lastChild.textContent="Error: Can't reach AI.";}
-};
+// Click outside to close
+window.addEventListener('click', e => {
+  qsa('.modal-overlay.active').forEach(m => {
+    if (e.target === m) m.classList.remove('active');
+  });
+});
+// Escape key to close
+window.addEventListener('keydown', e => {
+  if (e.key === 'Escape') {
+    qsa('.modal-overlay.active').forEach(m => m.classList.remove('active'));
+  }
+});
+
+/* ---------- Mobile nav + Global Page Toggles (from original fab-modal.js) ---------- */
+if (qs('#menuToggle')) {
+  qs('#menuToggle').onclick = () => {
+    const mobileNav = qs('#mobileNav');
+    if (mobileNav) mobileNav.classList.toggle('active');
+  };
+}
+
+if (qs('#mobile-services-toggle')) {
+  qs('#mobile-services-toggle').onclick = () => {
+    const mobileServicesMenu = qs('#mobile-services-menu');
+    if (mobileServicesMenu) mobileServicesMenu.classList.toggle('active');
+  };
+}
+
+// Global Language Toggle (for main page content via mobile nav)
+if (qs('#mobile-language-toggle')) {
+  qs('#mobile-language-toggle').onclick = () => {
+    const toggleButton = qs('#mobile-language-toggle');
+    const isEN = toggleButton.textContent === 'EN';
+    const targetLang = isEN ? 'es' : 'en';
+    document.documentElement.lang = targetLang; // Set overall page lang
+
+    // Toggle elements with data-en/data-es outside of specific modals
+    qsa('body [data-en][data-es]').forEach(el => {
+        // Avoid changing elements within modals that have their own toggles
+        if (!el.closest('#chatbot-container') && !el.closest('#joinModal .modal-content')) {
+            el.textContent = el.dataset[targetLang];
+        }
+    });
+    toggleButton.textContent = isEN ? 'ES' : 'EN';
+  };
+}
+
+// Global Theme Toggle (for main page via mobile nav)
+if (qs('#mobile-theme-toggle')) {
+  qs('#mobile-theme-toggle').onclick = () => {
+    const toggleButton = qs('#mobile-theme-toggle');
+    const isLight = toggleButton.textContent === 'Light';
+    document.body.classList.toggle('dark', isLight);
+    toggleButton.textContent = isLight ? 'Dark' : 'Light';
+    // Potentially sync with local storage if other theme toggles use it
+    localStorage.setItem('theme', isLight ? 'dark' : 'light');
+  };
+}
+
+/* ---------- CHATBOT LOGIC (New - from user snippet) ---------- */
+// Ensure selectors are scoped if needed, or use the chatbot container as context
+const chatbotContainer = qs('#chatbot-container');
+if (chatbotContainer) {
+  const langCtrlChat = qs('#langCtrl', chatbotContainer); // Scoped to chatbot
+  const themeCtrlChat = qs('#themeCtrl', chatbotContainer); // Scoped to chatbot
+  const chatLog = qs('#chat-log', chatbotContainer);
+  const chatForm = qs('#chatbot-input-row', chatbotContainer); // This is the form
+  const chatInput = qs('#chatbot-input', chatbotContainer);
+  const chatSendBtn = qs('#chatbot-send', chatbotContainer);
+  const humanCheck = qs('#human-check', chatbotContainer);
+  const humanLabelChat = qs('#human-label', chatbotContainer); // for lang toggle
+  const titleChat = qs('#title', chatbotContainer); // for lang toggle
+
+  if (langCtrlChat) {
+    langCtrlChat.onclick = () => {
+      const toES = langCtrlChat.textContent === 'ES';
+      // Chatbot's own language state, doesn't affect global page lang
+      langCtrlChat.textContent = toES ? 'EN' : 'ES';
+      const targetLang = toES ? 'es' : 'en';
+
+      // Toggle text nodes within chatbot
+      if (titleChat) titleChat.textContent = titleChat.dataset[targetLang];
+      if (humanLabelChat) humanLabelChat.textContent = humanLabelChat.dataset[targetLang];
+
+      // Toggle placeholders within chatbot
+      if (chatInput) chatInput.placeholder = chatInput.dataset[toES ? 'esPh' : 'enPh'];
+    };
+  }
+
+  if (themeCtrlChat) {
+    themeCtrlChat.onclick = () => {
+      const dark = themeCtrlChat.textContent === 'Dark';
+      document.body.classList.toggle('dark', dark); // This toggles global body theme
+      themeCtrlChat.textContent = dark ? 'Light' : 'Dark';
+      localStorage.setItem('theme', dark ? 'dark' : 'light'); // Sync with localStorage
+      // Also update global theme button if it exists
+      const globalThemeToggle = qs('#mobile-theme-toggle');
+      if (globalThemeToggle) globalThemeToggle.textContent = dark ? 'Dark' : 'Light';
+    };
+  }
+
+  if (humanCheck) {
+    humanCheck.onchange = () => {
+        if(chatSendBtn) chatSendBtn.disabled = !humanCheck.checked;
+    }
+  }
+
+  function addChatMsg(txt, cls) {
+    if (!chatLog) return;
+    const div = document.createElement('div');
+    div.className = 'chat-msg ' + cls; // Ensure .chat-msg.user or .chat-msg.bot
+    div.textContent = txt;
+    chatLog.appendChild(div);
+    chatLog.scrollTop = chatLog.scrollHeight;
+  }
+
+  if (chatForm) {
+    chatForm.onsubmit = async e => {
+      e.preventDefault();
+      if (!humanCheck || !humanCheck.checked) return;
+      if (!chatInput || !chatSendBtn) return;
+
+      const msg = chatInput.value.trim();
+      if (!msg) return;
+      addChatMsg(msg, 'user');
+      chatInput.value = '';
+      // chatSendBtn.disabled = true; // Disabling while waiting for reply could be good UX
+      addChatMsg('…', 'bot');
+
+      try {
+        // const r = await fetch('https://your-cloudflare-worker.example.com/chat', { // Placeholder URL
+        const r = await fetch('https://ops-ai-chatbot-worker.carlos-arias.workers.dev/chat', { // Actual Worker URL
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: msg })
+        });
+        const d = await r.json();
+        if (chatLog.lastChild) {
+            chatLog.lastChild.textContent = d.reply || 'No reply.';
+        }
+      } catch (err) {
+        console.error("Chatbot fetch error:", err);
+        if (chatLog.lastChild) {
+            chatLog.lastChild.textContent = 'Error: Can’t reach AI.';
+        }
+      }
+      // chatSendBtn.disabled = !humanCheck.checked; // Re-enable based on human check
+    };
+  }
+}
+
+
+/* ---------- JOIN US MODAL LOGIC (New - from user snippet) ---------- */
+const joinModal = qs('#joinModal');
+if (joinModal) {
+  let currentLangJoin = 'en'; // Language state specific to Join Us modal
+
+  const closeModalBtnJoin = qs('#close-modal-btn', joinModal);
+  const joinForm = qs('#join-form', joinModal);
+  const themeToggleJoin = qs('#theme-toggle', joinModal); // Specific theme toggle for Join Us
+  const langToggleJoin = qs('.lang-toggle', joinModal); // Specific lang toggle for Join Us
+
+  if (closeModalBtnJoin) {
+    closeModalBtnJoin.onclick = () => { // This is redundant if data-close is used, but harmless
+      joinModal.classList.remove('active');
+    };
+  }
+
+  if (joinForm) {
+    joinForm.addEventListener('submit', function(e) {
+      e.preventDefault();
+      alert(currentLangJoin === 'es' ? 'Formulario de Únete enviado.' : 'Join Us form submitted.');
+      joinModal.classList.remove('active'); // Close modal on submit
+    });
+  }
+
+  function updateLangJoin() {
+    // Title of the modal
+    const modalTitleJoin = qs('#joinModalSTitle', joinModal);
+    if(modalTitleJoin) modalTitleJoin.textContent = modalTitleJoin.dataset[currentLangJoin];
+
+    // Other elements with data-en/data-es within Join Us modal
+    qsa('[data-en]', joinModal).forEach(el => {
+      const translation = el.getAttribute(`data-${currentLangJoin}`);
+      if (translation) {
+        if (el.matches('input[type="button"]') || el.matches('button')) { // For buttons
+             if(el.matches('.lang-toggle')) {
+                el.textContent = currentLangJoin === 'en' ? 'EN | ES' : 'ES | EN';
+             } else {
+                el.textContent = translation;
+             }
+        } else if (el.tagName === 'H2' || el.tagName === 'H3' || el.tagName === 'LABEL' || el.tagName === 'SPAN' || el.tagName === 'P' || el.tagName === 'OPTION') {
+            if (!el.classList.contains('lang-toggle')) { // Don't re-translate the toggle button itself if it has data-en
+                 el.textContent = translation;
+            }
+        }
+      }
+    });
+
+    qsa('[data-placeholder-en]', joinModal).forEach(el => {
+      el.placeholder = el.getAttribute(`data-placeholder-${currentLangJoin}`);
+    });
+
+    qsa('[data-aria-label-en]', joinModal).forEach(el => {
+      el.setAttribute('aria-label', el.getAttribute(`data-aria-label-${currentLangJoin}`));
+    });
+
+    // Update document title if this modal is for a full page (not applicable here as it's a modal)
+    // const pageTitle = qs('title');
+    // if (pageTitle && pageTitle.dataset[currentLangJoin]) {
+    //    document.title = pageTitle.dataset[currentLangJoin];
+    // }
+  }
+
+  if (langToggleJoin) {
+    langToggleJoin.onclick = () => {
+      currentLangJoin = currentLangJoin === 'en' ? 'es' : 'en';
+      updateLangJoin();
+    };
+  }
+
+
+  function applyThemeJoin(theme) { // Theme function specific to Join Us modal's context if needed
+                                // but the new Join Us snippet toggles global 'dark-mode' class on body
+    if (theme === 'dark') {
+      document.body.classList.add('dark'); // Uses 'dark' to match global CSS
+      if (themeToggleJoin) themeToggleJoin.textContent = '☀️'; // Light icon for dark mode
+    } else {
+      document.body.classList.remove('dark');
+      if (themeToggleJoin) themeToggleJoin.textContent = '🌓'; // Dark icon for light mode
+    }
+     // Sync with global mobile nav theme button
+    const globalThemeToggle = qs('#mobile-theme-toggle');
+    if (globalThemeToggle) globalThemeToggle.textContent = theme === 'dark' ? 'Dark' : 'Light';
+  }
+
+  if (themeToggleJoin) {
+    themeToggleJoin.addEventListener('click', () => {
+      let newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+      localStorage.setItem('theme', newTheme);
+      applyThemeJoin(newTheme);
+    });
+  }
+
+  // Initial theme and lang setup for Join Us modal when page loads
+  // This was in DOMContentLoaded in the snippet, running it directly here.
+  const savedThemeJoin = localStorage.getItem('theme');
+  const systemPrefersDarkJoin = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (savedThemeJoin) {
+    applyThemeJoin(savedThemeJoin);
+  } else if (systemPrefersDarkJoin) {
+    applyThemeJoin('dark');
+  } else {
+    applyThemeJoin('light'); // Default to light
+  }
+  // updateLangJoin(); // Call to set initial language strings if needed when modal becomes visible or on page load.
+                      // Better to call this when the modal is opened.
+  const joinModalObserver = new MutationObserver((mutationsList, observer) => {
+    for(const mutation of mutationsList) {
+      if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+        if (joinModal.classList.contains('active')) {
+          updateLangJoin(); // Update language when modal becomes active
+        }
+      }
+    }
+  });
+  joinModalObserver.observe(joinModal, { attributes: true });
+
+
+  qsa('.form-section', joinModal).forEach(section => {
+    const addBtn = qs('.add', section);
+    const removeBtn = qs('.remove', section);
+    const acceptBtn = qs('.accept-btn', section);
+    const editBtn = qs('.edit-btn', section);
+    const inputsDiv = qs('.inputs', section); // Corrected selector
+    const titleEl = qs('h2', section); // Corrected selector
+
+    if (!addBtn || !removeBtn || !acceptBtn || !editBtn || !inputsDiv || !titleEl) return;
+
+    addBtn.onclick = () => {
+      const input = document.createElement('input');
+      input.type = 'text'; // Default type
+      const placeholderEn = `Enter ${titleEl.dataset.en || 'info'}`;
+      const placeholderEs = `Ingresa ${titleEl.dataset.es || 'información'}`;
+      input.setAttribute('data-placeholder-en', placeholderEn);
+      input.setAttribute('data-placeholder-es', placeholderEs);
+      input.placeholder = currentLangJoin === 'es' ? placeholderEs : placeholderEn;
+      inputsDiv.appendChild(input);
+      input.focus();
+    };
+
+    removeBtn.onclick = () => {
+      if (inputsDiv.lastElementChild && inputsDiv.lastElementChild.tagName === 'INPUT') {
+        inputsDiv.removeChild(inputsDiv.lastElementChild);
+      }
+    };
+
+    acceptBtn.onclick = () => {
+      if (!inputsDiv.children.length || !qs('input', inputsDiv)) { // Check if any input exists
+        alert(currentLangJoin === 'es' ? 'Agrega al menos una entrada.' : 'Please add at least one entry.');
+        return;
+      }
+      inputsDiv.querySelectorAll('input').forEach(input => input.disabled = true);
+      acceptBtn.style.display = 'none';
+      editBtn.style.display = 'inline-block';
+      section.classList.add('completed');
+    };
+
+    editBtn.onclick = () => {
+      inputsDiv.querySelectorAll('input').forEach(input => input.disabled = false);
+      acceptBtn.style.display = 'inline-block';
+      editBtn.style.display = 'none';
+      section.classList.remove('completed');
+      if(inputsDiv.querySelector('input')) inputsDiv.querySelector('input').focus();
+    };
+  });
+}
+
+
+/* ---------- CONTACT US MODAL LOGIC ---------- */
+// The new Contact Us HTML snippet did not include specific JS.
+// We can keep a simple submit alert based on the old form ID if it's still 'contactForm',
+// or the new 'contact-form' ID. The new HTML uses 'contact-form'.
+
+const contactForm = qs('#contact-form'); // New ID from the updated HTML
+if (contactForm) {
+  contactForm.onsubmit = e => {
+    e.preventDefault();
+    alert('Contact form submitted'); // Simple stub
+    const contactModal = qs('#contactModal');
+    if (contactModal) contactModal.classList.remove('active'); // Close modal on submit
+  };
+}
+
+// Ensure theme is applied on initial load based on localStorage or system preference
+document.addEventListener('DOMContentLoaded', () => {
+    const savedTheme = localStorage.getItem('theme');
+    const systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const globalThemeToggle = qs('#mobile-theme-toggle');
+    const chatbotThemeCtrl = qs('#chatbot-container #themeCtrl');
+    const joinUsThemeToggle = qs('#joinModal #theme-toggle');
+
+    let currentTheme = 'light'; // Default
+    if (savedTheme) {
+        currentTheme = savedTheme;
+    } else if (systemPrefersDark) {
+        currentTheme = 'dark';
+    }
+
+    document.body.classList.toggle('dark', currentTheme === 'dark');
+    if (globalThemeToggle) globalThemeToggle.textContent = currentTheme === 'dark' ? 'Dark' : 'Light';
+    if (chatbotThemeCtrl) chatbotThemeCtrl.textContent = currentTheme === 'dark' ? 'Light' : 'Dark'; // Text implies what it WILL turn into
+    if (joinUsThemeToggle) joinUsThemeToggle.textContent = currentTheme === 'dark' ? '☀️' : '🌓';
+
+
+    // Initial language for Join Us modal if it's visible on load (unlikely but for completeness)
+    if (joinModal && joinModal.classList.contains('active')) {
+        updateLangJoin();
+    }
+    // Initial language for Chatbot if visible on load
+    const chatbotTitle = qs('#chatbot-container #title');
+    const chatbotHumanLabel = qs('#chatbot-container #human-label');
+    const chatbotInput = qs('#chatbot-container #chatbot-input');
+    if(qs('#chatbot-container #langCtrl') && qs('#chatbot-container #langCtrl').textContent === 'EN') { // currently set to ES to toggle to EN
+        if(chatbotTitle) chatbotTitle.textContent = chatbotTitle.dataset.es;
+        if(chatbotHumanLabel) chatbotHumanLabel.textContent = chatbotHumanLabel.dataset.es;
+        if(chatbotInput) chatbotInput.placeholder = chatbotInput.dataset.esPh;
+    } else {
+        if(chatbotTitle) chatbotTitle.textContent = chatbotTitle.dataset.en;
+        if(chatbotHumanLabel) chatbotHumanLabel.textContent = chatbotHumanLabel.dataset.en;
+        if(chatbotInput) chatbotInput.placeholder = chatbotInput.dataset.enPh;
+    }
+
+});


### PR DESCRIPTION
- Updated HTML structures for Chatbot, Join Us, and Contact Us modals in index.html with new layouts, form elements, and ARIA attributes.
- Revised css/fab-modal.css:
  - Defined a new color scheme in :root (primary: #00c4ff, accent: #ff3bdb).
  - Updated base body styles to use the new color scheme.
  - Replaced CSS for Chatbot, Join Us, and Contact Us modals with new styles, including dark mode support aligned with the new theme.
- Updated js/fab-modal.js:
  - Integrated new JavaScript for Chatbot, including its internal language/theme toggles and API fetch logic (worker URL updated).
  - Integrated new JavaScript for Join Us modal, with its internal language/theme controls and dynamic form section handling.
  - Ensured existing global theme/language toggles and modal open/close mechanisms are compatible.
  - Added initial theme setup on DOMContentLoaded and language updates for modals when they become active.