### PR TITLE
Update FAB CSS for responsiveness

### DIFF
--- a/assets/css/mobile-fabs.css
+++ b/assets/css/mobile-fabs.css
@@ -1,14 +1,16 @@
 /* assets/css/mobile-fabs.css */
 
 /* ===== FAB Stack ===== */
-.fab-stack {
-  position: fixed;
-  bottom: 25px; /* Adjusted from 22px to 25px */
-  right: 22px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  z-index: 5000;
+@media (max-width: 768px) {
+  .fab-stack {
+    position: fixed;
+    bottom: 25px; /* Adjusted from 22px to 25px */
+    right: 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    z-index: 5000;
+  }
 }
 .fab-btn {
   width: var(--fab);
@@ -111,6 +113,9 @@
   }
 }
 @media (min-width: 769px) {
+  .fab-stack {
+    display: none;
+  }
   .mobile-nav,
   .mobile-services-menu {
     display: none !important;


### PR DESCRIPTION
## Summary
- wrap `.fab-stack` in a mobile media query
- hide floating buttons on wider screens

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e86fc3130832b9eba16387cb81520