### PR TITLE
UI tweaks for chatbot

### DIFF
--- a/assets/css/chatbot.css
+++ b/assets/css/chatbot.css
@@ -85,6 +85,7 @@
 #chatbot-input-row {
   display: flex;
   gap: .6rem;
+  align-items: center;
 }
 #chatbot-input {
   flex: 1;
@@ -97,24 +98,16 @@
   outline: none;
 }
 #chatbot-send {
-  display: flex;
-  align-items: center;
-  gap: 5px;
   background: var(--clr-accent, #ff3bdb);
   border: none;
   color: #fff;
   font-weight: 600;
-  padding: .48rem .85rem;
+  padding: .42rem .6rem;
   border-radius: 8px;
   cursor: pointer;
   transition: background .17s;
-  font-size: 1.05rem;
-}
-#chatbot-send i {
-  transition: transform .25s;
-}
-#chatbot-send:hover i {
-  transform: rotate(-45deg);
+  font-size: .9rem;
+  margin-left: .4rem;
 }
 #chatbot-send:disabled {
   background: #555;
@@ -125,7 +118,7 @@
   font-size: .87rem;
   display: flex;
   align-items: center;
-  margin-top: .31rem;
+  margin-left: .4rem;
 }
 .human-check input[type="checkbox"] {
   margin-right: .38rem;
@@ -156,14 +149,10 @@
     max-width: 85vw;
     max-height: 85vh;
     min-height: 0; /* Reset min-height */
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
 
-    /* Positioning of chatbot panel itself might need to be reviewed if FABs are now absolute/scrolling */
-    /* The 'right' positioning was relative to fixed FABs. */
-    /* If FABs are now absolute to body, this panel should also be positioned absolutely or fixed appropriately. */
-    /* For now, assuming its fixed positioning is still desired for the panel itself, relative to viewport. */
-    /* Its 'right' value might need to use the new 5px FAB right margin as a base. */
-    /* right: calc(5px + var(--fab-size) + var(--chatbot-horizontal-offset-from-fab-stack)); */
-    /* This needs to be considered with the new FAB positioning. */
-    /* For now, the primary goal is size. Positioning will be re-evaluated in testing. */
+    /* Positioning of chatbot panel centered for mobile */
   }
 }

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -19,7 +19,7 @@
   --fab-stack-gap: 12px;
 
   /* Chatbot Panel */
-  --chatbot-width: 310px;
+  --chatbot-width: 305px;
   --chatbot-height: 540px;
   --chatbot-inset-bottom: 35px; /* Also used for fab-stack upward movement */
   --chatbot-horizontal-offset-from-fab-stack: 3px; /* Gap between FAB stack and Chatbot panel */

--- a/components/chatbot/chatbot.html
+++ b/components/chatbot/chatbot.html
@@ -15,17 +15,15 @@
         <form id="chatbot-input-row" autocomplete="off">
           <input id="chatbot-input" type="text"
                  placeholder="Type your message..."
-                 required maxlength="256"
+                 required maxlength="200"
                  data-placeholder-en="Type your message..."
                  data-placeholder-es="Escriba su mensaje...">
-          <button id="chatbot-send" type="submit" disabled aria-label="Send">
-            <i class="fas fa-paper-plane"></i>
-          </button>
+          <label class="human-check">
+            <input type="checkbox" id="human-check">
+            <span id="human-label" data-en="I am human" data-es="Soy humano">I am human</span>
+          </label>
+          <button id="chatbot-send" type="submit" disabled aria-label="Send">SEND</button>
         </form>
-        <label class="human-check">
-          <input type="checkbox" id="human-check">
-          <span id="human-label" data-en="I am human" data-es="Soy humano">I am human</span>
-        </label>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -154,17 +154,15 @@
         <form id="chatbot-input-row" autocomplete="off">
           <input id="chatbot-input" type="text"
                  placeholder="Type your message..."
-                 required maxlength="256"
+                 required maxlength="200"
                  data-placeholder-en="Type your message..."
                  data-placeholder-es="Escriba su mensaje...">
-          <button id="chatbot-send" type="submit" disabled aria-label="Send">
-            <i class="fas fa-paper-plane"></i>
-          </button>
+          <label class="human-check">
+            <input type="checkbox" id="human-check">
+            <span id="human-label" data-en="I am human" data-es="Soy humano">I am human</span>
+          </label>
+          <button id="chatbot-send" type="submit" disabled aria-label="Send">SEND</button>
         </form>
-        <label class="human-check">
-          <input type="checkbox" id="human-check">
-          <span id="human-label" data-en="I am human" data-es="Soy humano">I am human</span>
-        </label>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- refactor chatbot input layout so send button sits next to checkbox
- trim chatbot panel width to 305px
- style send button with text only and smaller padding
- center chatbot panel on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68709616f6f4832bb3dac90bd9c29346