### PR TITLE
feat: Make modals draggable and remove backdrop

### DIFF
--- a/assets/css/chatbot.css
+++ b/assets/css/chatbot.css
@@ -39,6 +39,7 @@
   font-size: 1.12rem;
   padding: 0.8rem 1rem;
   letter-spacing: 1px;
+  cursor: move;
 }
 #chatbot-header .ctrl,
 #chatbot-modal-header .ctrl {

--- a/assets/css/modal.css
+++ b/assets/css/modal.css
@@ -2,13 +2,11 @@
 
 /* ===== Modal Overlay & Content ===== */
 .modal-overlay {
-  position: fixed;
+  position: absolute;
   top: 0; left: 0;
   width: 100vw; height: 100vh;
-  background: rgba(0, 0, 0, 0.5);
+  background: transparent;
   display: none;
-  align-items: center;
-  justify-content: center;
   z-index: 4000;
   padding: 1.2rem;
 }

--- a/assets/js/global-app.js
+++ b/assets/js/global-app.js
@@ -38,6 +38,17 @@ async function openModal(modalId, src) {
 
   if (modal) {
     modal.classList.add('active');
+    const modalContent = modal.querySelector('.modal-content');
+
+    if (modalContent && modalContent.classList.contains('modal-draggable')) {
+        // Center the modal
+        modalContent.style.left = `calc(50% - ${modalContent.offsetWidth / 2}px)`;
+        modalContent.style.top = `calc(50% - ${modalContent.offsetHeight / 2}px)`;
+
+        const dragHandle = modalContent.querySelector('.drag-handle') || modalContent;
+        makeDraggable(modalContent, dragHandle);
+    }
+
     // Re-apply language settings to newly loaded modal content
     const currentLang = document.documentElement.lang || 'en';
     updateTextContent(modal, currentLang);
@@ -378,6 +389,37 @@ document.body.addEventListener('submit', e => {
 });
 
 
+// ===== Draggable Modals =====
+function makeDraggable(modalContent, handle) {
+    let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+    handle.onmousedown = dragMouseDown;
+
+    function dragMouseDown(e) {
+        e = e || window.event;
+        e.preventDefault();
+        pos3 = e.clientX;
+        pos4 = e.clientY;
+        document.onmouseup = closeDragElement;
+        document.onmousemove = elementDrag;
+    }
+
+    function elementDrag(e) {
+        e = e || window.event;
+        e.preventDefault();
+        pos1 = pos3 - e.clientX;
+        pos2 = pos4 - e.clientY;
+        pos3 = e.clientX;
+        pos4 = e.clientY;
+        modalContent.style.top = (modalContent.offsetTop - pos2) + "px";
+        modalContent.style.left = (modalContent.offsetLeft - pos1) + "px";
+    }
+
+    function closeDragElement() {
+        document.onmouseup = null;
+        document.onmousemove = null;
+    }
+}
+
 // ===== Chatbot Inline Logic (Ops AI – Chattia) =====
 // Chatbot initialization is triggered when its modal is opened and interacted with.
 // The openModal function now calls attachModalHandlers, which is sufficient for basic setup.
@@ -396,6 +438,13 @@ document.body.addEventListener('click', function(e) {
 
 
 function chatbotInit(container) { // container is the chatbot panel or modal overlay
+  // Make the chatbot draggable
+  const modalContent = container.querySelector('.modal-content');
+  const dragHandle = container.querySelector('#chatbot-modal-header');
+  if (modalContent && dragHandle) {
+    makeDraggable(modalContent, dragHandle);
+  }
+
   // Chatbot-specific toggles can now leverage global functions
   const chatbotLangToggle = container.querySelector('#langCtrl, #chatbot-modal-langCtrl');
   const chatbotThemeToggle = container.querySelector('#themeCtrl, #chatbot-modal-themeCtrl');

--- a/components/chatbot/chatbot.html
+++ b/components/chatbot/chatbot.html
@@ -1,8 +1,8 @@
 <!-- components/chatbot/chatbot.html -->
 <div class="modal-overlay" id="chatbotModal" role="dialog" aria-modal="true" aria-labelledby="chatbotModalTitle">
-  <div class="modal-content" style="padding:0; background:none; box-shadow:none; border-radius:22px;">
+  <div class="modal-content modal-draggable" style="padding:0; background:none; box-shadow:none; border-radius:22px;">
     <div id="chatbot-modal-container" aria-label="Ops AI – Chattia" tabindex="0">
-      <div id="chatbot-modal-header">
+      <div id="chatbot-modal-header" class="drag-handle">
         <span id="chatbot-modal-title" data-en="Ops AI – Chattia" data-es="Ops IA – Chattia">OpsAI Chattia</span>
         <div>
           <span id="chatbot-modal-langCtrl" class="ctrl" style="cursor:pointer;">ES</span>

--- a/components/service-modals/business-operations.html
+++ b/components/service-modals/business-operations.html
@@ -1,7 +1,7 @@
 <!-- components/service-modals/business-operations.html -->
 <div class="modal-overlay" id="businessOpsModal" role="dialog" aria-modal="true" aria-labelledby="businessOpsModalTitle">
-  <div class="modal-content" style="max-width:720px; padding:0;">
-    <div class="c-suite-modal-header" style="background:linear-gradient(90deg,#00c4ff,#ff3bdb);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
+  <div class="modal-content modal-draggable" style="max-width:720px; padding:0;">
+    <div class="c-suite-modal-header drag-handle" style="background:linear-gradient(90deg,#00c4ff,#ff3bdb);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
       <h2 id="businessOpsModalTitle" data-en="Business Operations" data-es="Operaciones Empresariales">Business Operations</h2>
       <p data-en="Strategic. Reliable. Scalable." data-es="Estratégico. Confiable. Escalable."></p>
     </div>

--- a/components/service-modals/contact-center.html
+++ b/components/service-modals/contact-center.html
@@ -1,7 +1,7 @@
 <!-- components/service-modals/contact-center.html -->
 <div class="modal-overlay" id="contactCenterModal" role="dialog" aria-modal="true" aria-labelledby="contactCenterModalTitle">
-  <div class="modal-content" style="max-width:720px; padding:0;">
-    <div class="c-suite-modal-header" style="background:linear-gradient(90deg,#ff3bdb,#00c4ff);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
+  <div class="modal-content modal-draggable" style="max-width:720px; padding:0;">
+    <div class="c-suite-modal-header drag-handle" style="background:linear-gradient(90deg,#ff3bdb,#00c4ff);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
       <h2 id="contactCenterModalTitle" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</h2>
       <p data-en="Connected. Responsive. Customer-first." data-es="Conectado. Ágil. Orientado al Cliente."></p>
     </div>

--- a/components/service-modals/it-support.html
+++ b/components/service-modals/it-support.html
@@ -1,7 +1,7 @@
 <!-- components/service-modals/it-support.html -->
 <div class="modal-overlay" id="itSupportModal" role="dialog" aria-modal="true" aria-labelledby="itSupportModalTitle">
-  <div class="modal-content" style="max-width:720px; padding:0;">
-    <div class="c-suite-modal-header" style="background:linear-gradient(90deg,#7b2cbf,#00c4ff);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
+  <div class="modal-content modal-draggable" style="max-width:720px; padding:0;">
+    <div class="c-suite-modal-header drag-handle" style="background:linear-gradient(90deg,#7b2cbf,#00c4ff);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
       <h2 id="itSupportModalTitle" data-en="IT Support" data-es="Soporte IT"></h2>
       <p data-en="Secure. Fast. Proactive." data-es="Seguro. Rápido. Proactivo."></p>
     </div>

--- a/components/service-modals/professionals.html
+++ b/components/service-modals/professionals.html
@@ -1,7 +1,7 @@
 <!-- components/service-modals/professionals.html -->
 <div class="modal-overlay" id="professionalsModal" role="dialog" aria-modal="true" aria-labelledby="professionalsModalTitle">
-  <div class="modal-content" style="max-width:720px; padding:0;">
-    <div class="c-suite-modal-header" style="background:linear-gradient(90deg,#00c4ff,#ad30c0);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
+  <div class="modal-content modal-draggable" style="max-width:720px; padding:0;">
+    <div class="c-suite-modal-header drag-handle" style="background:linear-gradient(90deg,#00c4ff,#ad30c0);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
       <h2 id="professionalsModalTitle" data-en="Professionals" data-es="Profesionales"></h2>
       <p data-en="Expertise. Integrity. Results." data-es="Experticia. Integridad. Resultados."></p>
     </div>


### PR DESCRIPTION
This change makes the chatbot and service modals draggable and removes the semi-transparent backdrop.

- Modified `assets/css/modal.css` to remove the modal backdrop.
- Modified `assets/css/chatbot.css` to add a move cursor to the chatbot header.
- Added a `makeDraggable` function to `assets/js/global-app.js` to handle drag-and-drop functionality.
- Updated `openModal` and `chatbotInit` to use the `makeDraggable` function.
- Updated the chatbot and service modals to be draggable.