### PR TITLE
feat: Make modals draggable, resizable, and bring to front

### DIFF
--- a/assets/css/chatbot.css
+++ b/assets/css/chatbot.css
@@ -39,6 +39,7 @@
   font-size: 1.12rem;
   padding: 0.8rem 1rem;
   letter-spacing: 1px;
+  cursor: move;
 }
 #chatbot-header .ctrl,
 #chatbot-modal-header .ctrl {

--- a/assets/css/modal.css
+++ b/assets/css/modal.css
@@ -2,13 +2,11 @@
 
 /* ===== Modal Overlay & Content ===== */
 .modal-overlay {
-  position: fixed;
+  position: absolute;
   top: 0; left: 0;
   width: 100vw; height: 100vh;
-  background: rgba(0, 0, 0, 0.5);
+  background: transparent;
   display: none;
-  align-items: center;
-  justify-content: center;
   z-index: 4000;
   padding: 1.2rem;
 }
@@ -81,6 +79,16 @@
     max-width: 85vw; /* Ensure desktop max-width is overridden */
     max-height: 85vh; /* Ensure desktop max-height is overridden */
   }
+}
+
+.resize-handle {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 15px;
+    height: 15px;
+    background: #ccc;
+    cursor: nwse-resize;
 }
 
 

--- a/components/chatbot/chatbot.html
+++ b/components/chatbot/chatbot.html
@@ -1,8 +1,8 @@
 <!-- components/chatbot/chatbot.html -->
 <div class="modal-overlay" id="chatbotModal" role="dialog" aria-modal="true" aria-labelledby="chatbotModalTitle">
-  <div class="modal-content" style="padding:0; background:none; box-shadow:none; border-radius:22px;">
+  <div class="modal-content modal-draggable" style="padding:0; background:none; box-shadow:none; border-radius:22px;">
     <div id="chatbot-modal-container" aria-label="Ops AI – Chattia" tabindex="0">
-      <div id="chatbot-modal-header">
+      <div id="chatbot-modal-header" class="drag-handle">
         <span id="chatbot-modal-title" data-en="Ops AI – Chattia" data-es="Ops IA – Chattia">OpsAI Chattia</span>
         <div>
           <span id="chatbot-modal-langCtrl" class="ctrl" style="cursor:pointer;">ES</span>
@@ -26,5 +26,6 @@
         </form>
       </div>
     </div>
+    <div class="resize-handle"></div>
   </div>
 </div>

--- a/components/service-modals/business-operations.html
+++ b/components/service-modals/business-operations.html
@@ -1,7 +1,7 @@
 <!-- components/service-modals/business-operations.html -->
 <div class="modal-overlay" id="businessOpsModal" role="dialog" aria-modal="true" aria-labelledby="businessOpsModalTitle">
-  <div class="modal-content" style="max-width:720px; padding:0;">
-    <div class="c-suite-modal-header" style="background:linear-gradient(90deg,#00c4ff,#ff3bdb);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
+  <div class="modal-content modal-draggable" style="max-width:720px; padding:0;">
+    <div class="c-suite-modal-header drag-handle" style="background:linear-gradient(90deg,#00c4ff,#ff3bdb);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
       <h2 id="businessOpsModalTitle" data-en="Business Operations" data-es="Operaciones Empresariales">Business Operations</h2>
       <p data-en="Strategic. Reliable. Scalable." data-es="Estratégico. Confiable. Escalable."></p>
     </div>
@@ -33,6 +33,7 @@
         </div>
       </div>
     </div>
+    <div class="resize-handle"></div>
   </div>
 </div>
 

--- a/components/service-modals/contact-center.html
+++ b/components/service-modals/contact-center.html
@@ -1,7 +1,7 @@
 <!-- components/service-modals/contact-center.html -->
 <div class="modal-overlay" id="contactCenterModal" role="dialog" aria-modal="true" aria-labelledby="contactCenterModalTitle">
-  <div class="modal-content" style="max-width:720px; padding:0;">
-    <div class="c-suite-modal-header" style="background:linear-gradient(90deg,#ff3bdb,#00c4ff);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
+  <div class="modal-content modal-draggable" style="max-width:720px; padding:0;">
+    <div class="c-suite-modal-header drag-handle" style="background:linear-gradient(90deg,#ff3bdb,#00c4ff);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
       <h2 id="contactCenterModalTitle" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</h2>
       <p data-en="Connected. Responsive. Customer-first." data-es="Conectado. Ágil. Orientado al Cliente."></p>
     </div>
@@ -31,6 +31,7 @@
         </div>
       </div>
     </div>
+    <div class="resize-handle"></div>
   </div>
 </div>
 

--- a/components/service-modals/it-support.html
+++ b/components/service-modals/it-support.html
@@ -1,7 +1,7 @@
 <!-- components/service-modals/it-support.html -->
 <div class="modal-overlay" id="itSupportModal" role="dialog" aria-modal="true" aria-labelledby="itSupportModalTitle">
-  <div class="modal-content" style="max-width:720px; padding:0;">
-    <div class="c-suite-modal-header" style="background:linear-gradient(90deg,#7b2cbf,#00c4ff);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
+  <div class="modal-content modal-draggable" style="max-width:720px; padding:0;">
+    <div class="c-suite-modal-header drag-handle" style="background:linear-gradient(90deg,#7b2cbf,#00c4ff);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
       <h2 id="itSupportModalTitle" data-en="IT Support" data-es="Soporte IT"></h2>
       <p data-en="Secure. Fast. Proactive." data-es="Seguro. Rápido. Proactivo."></p>
     </div>
@@ -31,6 +31,7 @@
         </div>
       </div>
     </div>
+    <div class="resize-handle"></div>
   </div>
 </div>
 

--- a/components/service-modals/professionals.html
+++ b/components/service-modals/professionals.html
@@ -1,7 +1,7 @@
 <!-- components/service-modals/professionals.html -->
 <div class="modal-overlay" id="professionalsModal" role="dialog" aria-modal="true" aria-labelledby="professionalsModalTitle">
-  <div class="modal-content" style="max-width:720px; padding:0;">
-    <div class="c-suite-modal-header" style="background:linear-gradient(90deg,#00c4ff,#ad30c0);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
+  <div class="modal-content modal-draggable" style="max-width:720px; padding:0;">
+    <div class="c-suite-modal-header drag-handle" style="background:linear-gradient(90deg,#00c4ff,#ad30c0);color:#fff;padding:2rem 2rem 1.2rem 2rem;border-radius:14px 14px 0 0;">
       <h2 id="professionalsModalTitle" data-en="Professionals" data-es="Profesionales"></h2>
       <p data-en="Expertise. Integrity. Results." data-es="Experticia. Integridad. Resultados."></p>
     </div>
@@ -31,6 +31,7 @@
         </div>
       </div>
     </div>
+    <div class="resize-handle"></div>
   </div>
 </div>
 


### PR DESCRIPTION
This change makes the chatbot and service modals draggable, resizable, and brings them to the front when clicked.

- Constrained the drag area to the viewport to prevent scrollbars.
- Added a resize handle to the modals.
- Implemented the `makeResizable` function to handle resizing.
- Implemented the `bringToFront` function to manage the z-index of the modals.